### PR TITLE
adding ethnic and gender breakdowns

### DIFF
--- a/academic_affairs.sql
+++ b/academic_affairs.sql
@@ -2,6 +2,8 @@ WITH gather_data AS (
   SELECT
     Contact_Id,
     site_short,
+      Ethnic_background_c,
+      Gender_c,
     -- % of students with a 3.25 GPA
     -- Will need to make this more dynamic to account for GPA lag
     CASE
@@ -101,6 +103,8 @@ gather_survey_data AS (
 )
 SELECT
   GD.site_short,
+    GD.Ethnic_background_c,
+    GD.Gender_c,
   SUM(above_325_gpa) AS aa_above_325_gpa,
   SUM(composite_ready) AS aa_composite_ready,
   SUM(composite_ready_eleventh_grade) AS aa_composite_ready_eleventh_grade,
@@ -116,4 +120,6 @@ FROM
   LEFT JOIN aa_attendance_kpi AA ON GD.Contact_Id = AA.student_c
   LEFT JOIN gather_survey_data GSD ON GSD.contact_id = GD.contact_id
 GROUP BY
-  site_short
+  site_short,
+         Ethnic_background_c,
+         Gender_c

--- a/cc_hs.sql
+++ b/cc_hs.sql
@@ -1,328 +1,292 @@
 WITH gather_contact_data AS (
-    SELECT
-        contact_id,
-        site_short
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template` AS c
+SELECT 
+    contact_id,
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+
+FROM `data-warehouse-289815.salesforce_clean.contact_template` AS c 
 ),
-gather_11th_aspiration_data AS (
+
+
+gather_11th_aspiration_data AS ( 
     SELECT
         contact_id,
         site_short,
-        --11th Grade Aspirations, any Aspiration
-        SUM(
-            CASE
-                WHEN a.id IS NOT NULL THEN 1
-                ELSE 0
-            END
-        ) AS aspirations_any_count,
-        --11th Grade Aspirations, Affordable colleges
-        SUM(
-            CASE
-                WHEN fit_type_current_c IN ("Best Fit", "Good Fit", "Local Affordable") THEN 1
-                ELSE 0
-            END
-        ) AS aspirations_affordable_count,
-        --11th Grade Aspirations reporting group        
-        MAX(
-            CASE
-                WHEN (
-                    c.grade_c = '11th Grade'
-                    AND college_track_status_c = '11A'
-                ) THEN 1
-                ELSE 0
-            END
-        ) AS aspirations_denom_count
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template` AS c
-        LEFT JOIN `data-warehouse-289815.salesforce.college_aspiration_c` a ON c.contact_id = a.student_c
-    WHERE
-        college_track_status_c = '11A'
-        AND c.grade_c = '11th Grade'
+            
+     --11th Grade Aspirations, any Aspiration
+        SUM(CASE 
+            WHEN a.id IS NOT NULL 
+            THEN 1
+            ELSE 0
+            END) AS aspirations_any_count,
+            
+    --11th Grade Aspirations, Affordable colleges
+        SUM(CASE
+            WHEN fit_type_current_c IN ("Best Fit","Good Fit","Local Affordable") 
+            THEN 1
+            ELSE 0
+            END) AS aspirations_affordable_count,
+            
+    --11th Grade Aspirations reporting group        
+        MAX(CASE 
+            WHEN (c.grade_c = '11th Grade'
+            AND college_track_status_c = '11A') THEN 1
+            ELSE 0
+            END) AS aspirations_denom_count,
+            
+        c.Ethnic_background_c,
+        c.Gender_c
+            
+    FROM `data-warehouse-289815.salesforce_clean.contact_template` AS c
+    LEFT JOIN`data-warehouse-289815.salesforce.college_aspiration_c` a ON c.contact_id=a.student_c
+    WHERE college_track_status_c = '11A'
+    AND c. grade_c = '11th Grade'
     GROUP BY
         contact_id,
-        site_short
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
+
 --CT students for 10th grade EFC KPI
 gather_10th_efc_data AS (
-    SELECT
+SELECT
         contact_id,
         site_short,
-        --10th Grade EFC, FAFSA4Caster only
+        
+         --10th Grade EFC, FAFSA4Caster only
         CASE
-            WHEN (
-                c.grade_c = "10th Grade"
-                AND FA_Req_Expected_Financial_Contribution_c IS NOT NULL
-                AND fa_req_efc_source_c = 'FAFSA4caster'
-            ) THEN 1
+            WHEN (c.grade_c = "10th Grade" 
+            AND FA_Req_Expected_Financial_Contribution_c IS NOT NULL 
+            AND fa_req_efc_source_c = 'FAFSA4caster') THEN 1
             ELSE 0
-        END AS hs_EFC_10th_count,
+            END AS hs_EFC_10th_count,
+            
         CASE
-            WHEN (
-                c.grade_c = "10th Grade"
-                AND college_track_status_c = '11A'
-            ) THEN 1
+            WHEN (c.grade_c = "10th Grade" 
+            AND college_track_status_c = '11A') THEN 1
             ELSE 0
-        END AS hs_EFC_10th_denom_count
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template` AS c
-    WHERE
-        college_track_status_c = '11A'
-        AND grade_c = '10th Grade'
+            END AS hs_EFC_10th_denom_count,
+            
+        Ethnic_background_c,
+        Gender_c
+
+FROM `data-warehouse-289815.salesforce_clean.contact_template` AS c
+WHERE college_track_status_c = '11A'
+    AND grade_c = '10th Grade'
 ),
+
 --for 12th grade KPI: 80% CC attendance
-gather_attendance_data AS (
-    SELECT
-        c.student_c,
+gather_attendance_data AS ( 
+    SELECT 
+        c.student_c, 
         CASE
             WHEN SUM(Attendance_Denominator_c) = 0 THEN NULL
             ELSE SUM(Attendance_Numerator_c) / SUM(Attendance_Denominator_c)
-        END AS attendance_rate
-    FROM
-        `data-warehouse-289815.salesforce_clean.class_template` AS c
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.global_academic_semester_c = c.global_academic_semester_c
-    WHERE
-        Department_c = "College Completion"
-        AND Cancelled_c = FALSE
-        AND (
-            workshop_display_name_c LIKE '%Junior Advisory%'
-            OR workshop_display_name_c LIKE '%Senior Advisory%'
-            OR workshop_display_name_c LIKE '%Senior Seminar%'
-            OR workshop_display_name_c LIKE '%College Exposure%'
-        )
-        AND CAT.AY_Name = 'AY 2020-21'
-        AND college_track_status_c = '11A'
-        AND (
-            grade_c = "12th Grade"
-            OR (
-                grade_c = 'Year 1'
-                AND indicator_years_since_hs_graduation_c = 0
-            )
-        )
-    GROUP BY
+            END AS attendance_rate
+    FROM `data-warehouse-289815.salesforce_clean.class_template` AS c
+        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT 
+        ON CAT.global_academic_semester_c = c.global_academic_semester_c
+    WHERE Department_c = "College Completion"
+    AND Cancelled_c = FALSE
+    AND (workshop_display_name_c LIKE '%Junior Advisory%'
+        OR workshop_display_name_c LIKE '%Senior Advisory%'
+        OR workshop_display_name_c LIKE '%Senior Seminar%'
+        OR workshop_display_name_c LIKE '%College Exposure%')
+    AND CAT.AY_Name = 'AY 2020-21'
+    AND college_track_status_c = '11A'
+    AND (grade_c = "12th Grade" OR (grade_c='Year 1' AND indicator_years_since_hs_graduation_c = 0))
+    GROUP BY 
         c.student_c
 ),
+
 --Affordable college KPIs: Applying and Acceptance to Affordable Colleges and/or Best Fit/Good Fit schools only
 gather_data_twelfth_grade AS (
-    SELECT
-        contact_id,
+    SELECT 
+        CT.contact_id,
         attendance_rate,
-        site_short,
-        --% students completing the financial aid submission and verification processes
+        CT.site_short,
+        
+    --% students completing the financial aid submission and verification processes
         --May need to confirm which college applications should be included (e.g. accepted and enrolled/deferred). Currently pulling any college app
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq1
-            WHERE
-                FA_Req_FAFSA_c = 'Submitted'
-                AND (
-                    verification_status_c IN ('Submitted', 'Not Applicable')
-                )
-                AND Contact_Id = student_c
-            group by
-                student_c
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq1
+        WHERE FA_Req_FAFSA_c = 'Submitted' 
+        AND (verification_status_c IN ('Submitted','Not Applicable')) 
+        AND Contact_Id=student_c
+        group by student_c
         ) AS gather_fafsa_verification,
-        --% of acceptances to Affordable colleges. This will be done in 2 parts since this can live in 2 fields: Fit Type (Applied), Fit Type (Enrolled)
+    
+    --% of acceptances to Affordable colleges. This will be done in 2 parts since this can live in 2 fields: Fit Type (Applied), Fit Type (Enrolled)
         --Pulling in students that were accepted to an affordable option. 
         --Accepted & Enrolled/Deferred Affordable options will also be pulled in, but in another query below since these will live in Fit Type (enrolled) field
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq1
-            WHERE
-                (
-                    admission_status_c = "Accepted"
-                    AND College_Fit_Type_Applied_c IN ("Best Fit", "Good Fit", "Local Affordable")
-                )
-                AND Contact_Id = student_c
-            group by
-                student_c
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq1
+        WHERE (admission_status_c = "Accepted" AND College_Fit_Type_Applied_c IN ("Best Fit","Good Fit","Local Affordable"))
+        AND Contact_Id=student_c
+        group by student_c
         ) AS applied_accepted_affordable,
-        --% of acceptances to Affordable colleges; % hs seniors who matriculate to affordable college
+        
+     --% of acceptances to Affordable colleges; % hs seniors who matriculate to affordable college
         --Pulling in from Fit Type (enrolled)
         --Will also be used to project matriculation to affordable colleges
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq2
-            WHERE
-                admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred")
-                AND fit_type_enrolled_c IN (
-                    "Best Fit",
-                    "Good Fit",
-                    "Local Affordable",
-                    "Situational"
-                )
-                AND Contact_Id = student_c
-            group by
-                student_c
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq2
+        WHERE admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred") AND fit_type_enrolled_c IN ("Best Fit","Good Fit","Local Affordable","Situational")
+        AND Contact_Id=student_c
+        group by student_c
         ) AS accepted_enrolled_affordable,
-        --% accepted to Best Fit, Good Fit
+    
+    --% accepted to Best Fit, Good Fit
         --Same logic as the 2 queries above, except only looking at Good Fit and Best Fit in Fit Type (Applied)     
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq4
-            WHERE
-                admission_status_c = "Accepted"
-                AND College_Fit_Type_Applied_c IN ("Best Fit", "Good Fit")
-                AND Contact_Id = student_c
-            group by
-                student_c
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq4
+        WHERE admission_status_c = "Accepted" AND College_Fit_Type_Applied_c IN ("Best Fit","Good Fit")
+        AND Contact_Id=student_c
+        group by student_c
         ) AS applied_accepted_best_good,
-        --% accepted to Best Fit, Good Fit; % hs seniors who matriculate to Good/Best/Situational
+    
+    --% accepted to Best Fit, Good Fit; % hs seniors who matriculate to Good/Best/Situational
         --Same logic as the 2 queries above, except only looking at Good Fit and Best Fit in Fit Type (Enrolled) 
-        -- Will also be used to project matriculation
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq5
-            WHERE
-                admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred")
-                AND fit_type_enrolled_c IN ("Best Fit", "Good Fit", "Situational")
-                AND Contact_Id = student_c
-            group by
-                student_c
+    -- Will also be used to project matriculation
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq5
+        WHERE admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred") AND fit_type_enrolled_c IN ("Best Fit","Good Fit","Situational")
+        AND Contact_Id=student_c
+        group by student_c
         ) AS accepted_enrolled_best_good_situational,
-        --% applying to Best Fit and Good Fit colleges
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq3
-            WHERE
-                College_Fit_Type_Applied_c IN ("Best Fit", "Good Fit")
-                AND Contact_Id = student_c
-            group by
-                student_c
+    
+    --% applying to Best Fit and Good Fit colleges
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq3
+        WHERE College_Fit_Type_Applied_c IN ("Best Fit","Good Fit")  
+        AND Contact_Id=student_c
+        group by student_c
         ) AS applied_best_good,
-        --Students and families are prepared to enter strong college situations
-        --The following assumes that when you accept and enroll, are waitlisted, or deferred for FY22,
-        --you have had a conversation with a parent and student, which is part of dosage. 
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq2
-            WHERE
-                admission_status_c IN (
-                    "Accepted and Enrolled",
-                    "Accepted and Deferred",
-                    "Wait-listed"
-                )
-                AND Contact_Id = student_c
-            group by
-                student_c
-        ) AS accepted_enrolled_waitlisted
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template`
-        LEFT JOIN gather_attendance_data ON contact_id = student_c
-    WHERE
-        college_track_status_c = '11A'
-        AND (
-            grade_c = "12th Grade"
-            OR (
-                grade_c = 'Year 1'
-                AND indicator_years_since_hs_graduation_c = 0
-            )
-        )
+        
+    --Students and families are prepared to enter strong college situations
+    --The following assumes that when you accept and enroll, are waitlisted, or deferred for FY22,
+    --you have had a conversation with a parent and student, which is part of dosage. 
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq2
+        WHERE admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred","Wait-listed")
+        AND Contact_Id=student_c
+        group by student_c
+        ) AS accepted_enrolled_waitlisted,
+        
+        CT.Ethnic_background_c,
+        CT.Gender_c
+            
+      
+    FROM `data-warehouse-289815.salesforce_clean.contact_template` AS CT
+        LEFT JOIN gather_attendance_data ON CT.contact_id=student_c
+    WHERE  college_track_status_c = '11A'
+    AND (grade_c = "12th Grade" OR (grade_c='Year 1' AND indicator_years_since_hs_graduation_c = 0))
 ),
+
 --Prepping 11th grade College Aspirations for aggregation
-gather_eleventh_grade_metrics AS (
-    SELECT
-        site_short,
-        aspirations_denom_count,
-        CASE
-            WHEN (
-                aspirations_any_count >= 6
-                AND aspirations_affordable_count >= 3
-            ) THEN 1
-            ELSE 0
-        END AS cc_hs_aspirations_num_prep
-    FROM
-        gather_11th_aspiration_data
-    GROUP BY
-        contact_id,
-        site_short,
-        aspirations_denom_count,
-        aspirations_any_count,
-        aspirations_affordable_count
+gather_eleventh_grade_metrics AS ( 
+ SELECT
+    site_short,
+    aspirations_denom_count,
+    CASE 
+        WHEN (aspirations_any_count >= 6 AND aspirations_affordable_count >= 3) 
+        THEN 1
+        ELSE 0
+        END AS cc_hs_aspirations_num_prep,
+    Ethnic_background_c,
+    Gender_c
+    
+    FROM gather_11th_aspiration_data
+    GROUP BY contact_id,site_short, aspirations_denom_count,aspirations_any_count,aspirations_affordable_count,Ethnic_background_c,Gender_c
 ),
+
 --Prepping attendance data, FAFSA Verification KPI, Affordable college data for aggregation
 gather_twelfth_grade_metrics AS(
-    SELECT
+    SELECT  
         site_short,
-        CASE
+        CASE 
             WHEN attendance_rate >= 0.8 THEN 1
             ELSE 0
-        END AS cc_hs_above_80_cc_attendance,
+            END AS cc_hs_above_80_cc_attendance,
         CASE
             WHEN gather_fafsa_verification IS NOT NULL THEN 1
             ELSE 0
-        END AS fafsa_verification_prep,
-        CASE
+            END AS fafsa_verification_prep,
+        CASE 
             WHEN accepted_enrolled_affordable IS NOT NULL THEN 1
             WHEN applied_accepted_affordable IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_accepted_affordable,
-        CASE
+            END AS cc_hs_accepted_affordable,
+        CASE 
             WHEN applied_best_good IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_applied_best_good,
-        CASE
+            END AS cc_hs_applied_best_good,
+        CASE 
             WHEN accepted_enrolled_best_good_situational IS NOT NULL THEN 1
             WHEN applied_accepted_best_good IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_accepted_best_good_situational,
-        --Matriculation data not available yet, so projecting matriculation based on College Application enrollment data
-        CASE
+            END AS cc_hs_accepted_best_good_situational,
+            
+    --Matriculation data not available yet, so projecting matriculation based on College Application enrollment data
+        CASE 
             WHEN accepted_enrolled_best_good_situational IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_enrolled_best_good_situational,
-        --Matriculation data not available yet, so projecting matriculation based on College Application enrollment data
-        CASE
+            END AS cc_hs_enrolled_best_good_situational,  
+            
+    --Matriculation data not available yet, so projecting matriculation based on College Application enrollment data
+        CASE 
             WHEN accepted_enrolled_affordable IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_enrolled_affordable,
-        --Students and families are prepared to enter strong college situations
-        CASE
+            END AS cc_hs_enrolled_affordable, 
+            
+    --% of 12th graders and families participating in 1+ college choice conversation
+    --Students and families are prepared to enter strong college situations
+        CASE 
             WHEN accepted_enrolled_waitlisted IS NOT NULL THEN 1
             ELSE 0
-        END AS cc_hs_strong_college_situations
-    FROM
-        gather_data_twelfth_grade
+            END AS cc_hs_strong_college_situations,
+            
+    Ethnic_background_c,
+    Gender_c
+            
+    FROM gather_data_twelfth_grade
 ),
+
+
 --Aggregating 10th Grade EFC KPI
-prep_tenth_grade_metrics AS (
-    SELECT
+prep_tenth_grade_metrics AS ( 
+    SELECT 
         site_short,
         SUM(hs_EFC_10th_count) AS cc_hs_EFC_10th_num,
-        SUM(hs_EFC_10th_denom_count) AS cc_hs_EFC_10th_denom
-    FROM
-        gather_10th_efc_data
-    GROUP BY
-        site_short
+        SUM(hs_EFC_10th_denom_count) AS cc_hs_EFC_10th_denom,
+        Ethnic_background_c,
+        Gender_c
+    FROM gather_10th_efc_data
+    GROUP BY 
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
+
 --Aggregating 11th grade College Aspirations KPI
-prep_eleventh_grade_metrics AS (
-    SELECT
+prep_eleventh_grade_metrics AS ( 
+    SELECT 
         site_short,
         SUM(cc_hs_aspirations_num_prep) AS cc_hs_aspirations_num,
-        SUM(aspirations_denom_count) AS cc_hs_aspirations_denom
-    FROM
-        gather_eleventh_grade_metrics
-    GROUP BY
-        site_short
+        SUM(aspirations_denom_count) AS cc_hs_aspirations_denom,
+        Ethnic_background_c,
+        Gender_c
+    FROM gather_eleventh_grade_metrics
+    GROUP BY 
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
 --Aggregating 12th grade KPIs: CC Attendance 80%, Affordable Colleges, Best Fit/Good Fit colleges, FAFSA verification
 prep_twelfth_grade_metrics AS (
-    SELECT
+    SELECT 
         site_short,
         SUM(cc_hs_above_80_cc_attendance) AS cc_hs_above_80_cc_attendance,
         SUM(cc_hs_accepted_affordable) AS cc_hs_accepted_affordable,
@@ -331,30 +295,30 @@ prep_twelfth_grade_metrics AS (
         SUM(cc_hs_strong_college_situations) AS cc_hs_strong_college_situations,
         SUM(fafsa_verification_prep) AS cc_hs_financial_aid_submission_verification,
         SUM(cc_hs_enrolled_best_good_situational) AS cc_hs_enrolled_best_good_situational,
-        SUM(cc_hs_enrolled_affordable) AS cc_hs_enrolled_affordable
-    FROM
-        gather_twelfth_grade_metrics
-    GROUP BY
-        site_short
-) #final kpi join
-SELECT
+        SUM(cc_hs_enrolled_affordable) AS cc_hs_enrolled_affordable,
+        Ethnic_background_c,
+        Gender_c
+    FROM gather_twelfth_grade_metrics
+    GROUP BY 
+        site_short,
+        Ethnic_background_c,
+        Gender_c
+)
+
+#final kpi join
+SELECT 
     gd.site_short,
-    kpi_10th.*
-EXCEPT
-(site_short),
-    kpi_11th.*
-EXCEPT
-(site_short),
-    kpi_12th.*
-EXCEPT
-(site_short)
-FROM
-    gather_contact_data as gd
-    LEFT JOIN prep_tenth_grade_metrics AS kpi_10th ON gd.site_short = kpi_10th.site_short
-    LEFT JOIN prep_eleventh_grade_metrics AS kpi_11th ON gd.site_short = kpi_11th.site_short
-    LEFT JOIN prep_twelfth_grade_metrics AS kpi_12th ON gd.site_short = kpi_12th.site_short
+    kpi_10th.* EXCEPT(site_short,Ethnic_background_c,Gender_c),
+    kpi_11th.* EXCEPT(site_short,Ethnic_background_c,Gender_c),
+    kpi_12th.* EXCEPT(site_short,Ethnic_background_c,Gender_c),
+    gd.Ethnic_background_c,
+    gd.Gender_c
+    FROM gather_contact_data as gd
+        LEFT JOIN prep_tenth_grade_metrics AS kpi_10th ON gd.site_short = kpi_10th.site_short AND gd.Ethnic_background_c=kpi_10th.Ethnic_background_c AND gd.gender_c=kpi_10th.Gender_c
+        LEFT JOIN prep_eleventh_grade_metrics AS kpi_11th ON gd.site_short = kpi_11th.site_short AND gd.Ethnic_background_c=kpi_11th.Ethnic_background_c AND gd.Gender_c=kpi_11th.Gender_c
+        LEFT JOIN prep_twelfth_grade_metrics AS kpi_12th ON gd.site_short = kpi_12th.site_short AND gd.Ethnic_background_c=kpi_12th.Ethnic_background_c AND gd.Gender_c=kpi_12th.Gender_c
 GROUP BY
-    site_short,
+    site_short, 
     cc_hs_EFC_10th_num,
     cc_hs_EFC_10th_denom,
     cc_hs_aspirations_num,
@@ -365,6 +329,7 @@ GROUP BY
     cc_hs_accepted_affordable,
     cc_hs_applied_best_good,
     cc_hs_accepted_best_good_situational,
-    cc_hs_enrolled_best_good_situational,
-    #projecting matriculation
-    cc_hs_enrolled_affordable #projecting matriculation
+    cc_hs_enrolled_best_good_situational, #projecting matriculation
+    cc_hs_enrolled_affordable, #projecting matriculation
+    Ethnic_background_c,
+    Gender_c

--- a/cc_ps.sql
+++ b/cc_ps.sql
@@ -1,307 +1,302 @@
-WITH get_contact_data AS (
+WITH get_contact_data AS
+(
     SELECT
-        contact_Id,
-        site_short,
-        -- % of students graduating from college within 6 years (numerator)
-        -- uses alumni who've already graduated in current AY + active PS w/ credit pace < 6 years and enrolled full-time. cohort based. year 6. 
-        --will need to re-work for final as grade switches over 9/1 each year
-        CASE
-            WHEN grade_c = 'Year 6'
-            AND indicator_completed_ct_hs_program_c = true
-            AND (
-                (
-                    college_track_status_c = '15A'
-                    AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
-                    AND credits_accumulated_most_recent_c >= 80
-                    AND Current_Enrollment_Status_c = "Full-time"
-                    AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting"
-                )
-                OR college_track_status_c = '17A'
-            ) THEN 1
-            ELSE 0
+    contact_Id,
+    Gender_c,
+    Ethnic_background_c,
+    site_short,
+-- % of students graduating from college within 6 years (numerator)
+-- uses alumni who've already graduated in current AY + active PS w/ credit pace < 6 years and enrolled full-time. cohort based. year 6.
+--will need to re-work for final as grade switches over 9/1 each year
+    CASE
+      WHEN
+        grade_c = 'Year 6'
+        AND indicator_completed_ct_hs_program_c = true
+        AND
+        (
+         (college_track_status_c = '15A'
+         AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
+         AND credits_accumulated_most_recent_c >= 80
+         AND Current_Enrollment_Status_c = "Full-time"
+         AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting"
+         )
+        OR
+         college_track_status_c = '17A') THEN 1
+        ELSE 0
         END AS cc_ps_projected_grad_num,
-        -- % of students graduating from college within 6 years (denominator)
-        -- cohort based, year 6
-        CASE
-            WHEN (
-                grade_c = 'Year 6'
-                AND indicator_completed_ct_hs_program_c = true
-            ) THEN 1
-            ELSE 0
-        END AS cc_ps_projected_grad_denom,
-        --% of 2yr students transferring to a 4yr within 3 years
-        --cohort based, trending is students in year 3. final calc is done in fall of year 4.  Will need to be reworked for final
-        --numerator for trending shows which of the 2-year starters, currently in year 2 have already enrolled in a 4-year.
-        CASE
-            WHEN (
-                indicator_completed_ct_hs_program_c = true
-                AND college_track_status_c = '15A'
-                AND grade_c = 'Year 3'
-                AND school_type = '4-Year'
-                AND current_enrollment_status_c IN ("Full-time", "Part-time")
-                AND college_first_enrolled_school_type_c IN (
-                    "Predominantly associate's-degree granting",
-                    "Predominantly certificate-degree granting"
-                )
-            ) THEN 1
-            ELSE 0
+-- % of students graduating from college within 6 years (denominator)
+-- cohort based, year 6
+    CASE
+        WHEN
+        (grade_c = 'Year 6'
+        AND indicator_completed_ct_hs_program_c = true) THEN 1
+        ELSE 0
+    END AS cc_ps_projected_grad_denom,
+--% of 2yr students transferring to a 4yr within 3 years
+--cohort based, trending is students in year 3. final calc is done in fall of year 4.  Will need to be reworked for final
+--numerator for trending shows which of the 2-year starters, currently in year 2 have already enrolled in a 4-year.
+    CASE
+        WHEN
+        (indicator_completed_ct_hs_program_c = true
+        AND college_track_status_c = '15A'
+        AND grade_c = 'Year 3'
+        AND school_type = '4-Year'
+        AND current_enrollment_status_c IN ("Full-time","Part-time")
+        AND college_first_enrolled_school_type_c IN ("Predominantly associate's-degree granting","Predominantly certificate-degree granting")) THEN 1
+        ELSE 0
         END AS x_2_yr_transfer_num,
-        --denom for trending, currently in year 2 started at 2-year school or lower. Will need to be reworked for final
-        CASE
-            WHEN (
-                indicator_completed_ct_hs_program_c = true
-                AND grade_c = 'Year 3'
-                AND college_first_enrolled_school_type_c IN (
-                    "Predominantly associate's-degree granting",
-                    "Predominantly certificate-degree granting"
-                )
-            ) THEN 1
-            ELSE 0
+--denom for trending, currently in year 2 started at 2-year school or lower. Will need to be reworked for final
+    CASE
+        WHEN
+        (indicator_completed_ct_hs_program_c = true
+        AND grade_c = 'Year 3'
+        AND college_first_enrolled_school_type_c IN ("Predominantly associate's-degree granting","Predominantly certificate-degree granting")) THEN 1
+        ELSE 0
         END AS x_2_yr_transfer_denom,
-        --% of students graduating with 1+ internships
-        --Hardcoded AY will need to be updated next year
-        --trending used both alumni who've already graduated in AY + students anticipated to graduate in AY
-        --numerator
-        CASE
-            WHEN (
-                indicator_completed_ct_hs_program_c = true
-                AND ps_internships_c > 0
-                AND (
-                    (
-                        anticipated_date_of_graduation_ay_c = 'AY 2020-21'
-                        AND college_track_status_c = '15A'
-                        AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
-                        AND credits_accumulated_most_recent_c >= 80
-                        AND Current_Enrollment_Status_c = "Full-time"
-                        AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting"
-                    )
-                    OR academic_year_4_year_degree_earned_c = 'AY 2020-21'
-                )
-            ) THEN 1
-            ELSE 0
-        END AS cc_ps_grad_internship_num,
-        --denominator
-        CASE
-            WHEN (
-                indicator_completed_ct_hs_program_c = true
-                AND (
-                    (
-                        anticipated_date_of_graduation_ay_c = 'AY 2020-21'
-                        AND college_track_status_c = '15A'
-                        AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
-                        AND credits_accumulated_most_recent_c >= 80
-                        AND Current_Enrollment_Status_c = "Full-time"
-                        AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting"
-                    )
-                    OR academic_year_4_year_degree_earned_c = 'AY 2020-21'
-                )
-            ) THEN 1
-            ELSE 0
-        END AS cc_ps_grad_internship_denom,
-        --% of students with a 2.5+ cumulative GPA
-        --Will need to be reworked for final if we want to ensure we're pulling GPA from uniform point in time
-        CASE
-            WHEN (
-                indicator_completed_ct_hs_program_c = true
-                AND college_track_status_c = '15A'
-                AND Prev_AT_Cum_GPA >= 2.5
-            ) THEN 1
-            ELSE 0
-        END AS cc_ps_gpa_2_5_num,
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template` --needed widest reporting group to ensure I had all students I need to evaluate if they were in one of my custom denoms. Added in more detail filter logic into case statements above.
-    WHERE
-        indicator_completed_ct_hs_program_c = true
+
+--% of students graduating with 1+ internships
+--Hardcoded AY will need to be updated next year
+--trending used both alumni who've already graduated in AY + students anticipated to graduate in AY
+--numerator
+    CASE
+        WHEN
+        (indicator_completed_ct_hs_program_c = true
+        AND
+        ps_internships_c > 0
+        AND
+        ((anticipated_date_of_graduation_ay_c = 'AY 2020-21'
+         AND college_track_status_c = '15A'
+         AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
+         AND credits_accumulated_most_recent_c >= 80
+         AND Current_Enrollment_Status_c = "Full-time"
+         AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting")
+        OR
+        academic_year_4_year_degree_earned_c = 'AY 2020-21')) THEN 1
+        ELSE 0
+    END AS cc_ps_grad_internship_num,
+--denominator
+    CASE
+        WHEN
+        (indicator_completed_ct_hs_program_c = true
+        AND
+        ((anticipated_date_of_graduation_ay_c = 'AY 2020-21'
+         AND college_track_status_c = '15A'
+         AND Credit_Accumulation_Pace_c NOT IN ("6+ Years", 'Credit Data Missing')
+         AND credits_accumulated_most_recent_c >= 80
+         AND Current_Enrollment_Status_c = "Full-time"
+         AND Current_School_Type_c_degree = "Predominantly bachelor's-degree granting")
+        OR
+        academic_year_4_year_degree_earned_c = 'AY 2020-21')) THEN 1
+        ELSE 0
+    END AS cc_ps_grad_internship_denom,
+
+--% of students with a 2.5+ cumulative GPA
+--Will need to be reworked for final if we want to ensure we're pulling GPA from uniform point in time
+    CASE
+        WHEN
+        (indicator_completed_ct_hs_program_c = true
+        AND college_track_status_c = '15A'
+        AND Prev_AT_Cum_GPA >= 2.5) THEN 1
+        ELSE 0
+    END AS cc_ps_gpa_2_5_num,
+
+    FROM `data-warehouse-289815.salesforce_clean.contact_template`
+--needed widest reporting group to ensure I had all students I need to evaluate if they were in one of my custom denoms. Added in more detail filter logic into case statements above.
+    WHERE indicator_completed_ct_hs_program_c = true
 ),
+
 -- adv rubric data from current AT
 --numerators needed only, denom is all active PS students for these
-get_at_data AS (
+get_at_data AS
+(
     SELECT
-        AT_Id,
-        Contact_Id AS at_contact_id,
-        site_short AS at_site,
-        --% of students completing FAFSA or equivalent
-        CASE
-            WHEN filing_status_c = 'FS_G' THEN 1
-            ELSE 0
-        END AS indicator_fafsa_complete,
-        --% of students on-track to have less than $30K loan debt
-        CASE
-            WHEN loans_c IN ('LN_G', 'LN_Y') THEN 1
-            ELSE 0
-        END AS indicator_loans_less_30k_loans,
-        --% of students attaining a well-balanced lifestyle    
-        CASE
-            WHEN Overall_Rubric_Color = 'Green' THEN 1
-            ELSE 0
-        END AS indicator_well_balanced,
-        --% of students understand that technical and interpersonal skills are needed to create opportunities now and in the future
-        CASE
-            WHEN advising_rubric_career_readiness_v_2_c = 'Green'
-            AND (
-                academic_networking_50_cred_c = 'AN1_G'
-                OR academic_networking_over_50_credits_c = 'AN2_G'
-            ) THEN 1
-            ELSE 0
-        END AS indicator_tech_interpersonal_skills,
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template`
-    WHERE
-        college_track_status_c = '15A'
-        AND(
-            (
-                CURRENT_DATE() < '2021-07-01'
-                AND current_as_c = TRUE
-            )
-            OR (
-                CURRENT_DATE() > '2021-07-01'
-                AND previous_as_c = TRUE
-            )
-        )
+    AT_Id,
+    Gender_c AS at_gender,
+    Ethnic_background_c AS at_ethnic_background,
+    Contact_Id AS at_contact_id,
+    site_short AS at_site,
+--% of students completing FAFSA or equivalent
+    CASE
+        WHEN filing_status_c = 'FS_G' THEN 1
+        ELSE 0
+    END AS indicator_fafsa_complete,
+--% of students on-track to have less than $30K loan debt
+    CASE
+        WHEN
+        loans_c IN ('LN_G','LN_Y') THEN 1
+        ELSE 0
+    END AS indicator_loans_less_30k_loans,
+--% of students attaining a well-balanced lifestyle
+    CASE
+        WHEN Overall_Rubric_Color = 'Green' THEN 1
+        ELSE 0
+    END AS indicator_well_balanced,
+--% of students understand that technical and interpersonal skills are needed to create opportunities now and in the future
+    CASE
+        WHEN advising_rubric_career_readiness_v_2_c = 'Green'
+        AND
+        (academic_networking_50_cred_c = 'AN1_G'
+        OR academic_networking_over_50_credits_c = 'AN2_G') THEN 1
+        ELSE 0
+    END AS indicator_tech_interpersonal_skills,
+
+    FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+    WHERE college_track_status_c = '15A'
+    AND(
+    (CURRENT_DATE() < '2021-07-01'
+    AND current_as_c = TRUE)
+    OR
+    (CURRENT_DATE() > '2021-07-01'
+    AND previous_as_c = TRUE))
 ),
+
 --% of students who persist into the following year (all college students)
 --first pulling in all ATs for time period I want (last fall to next fall)
-get_persist_at_data AS (
-    SELECT
-        contact_id AS persist_contact_id,
-        --indicator to flag which students were enrolled in any college last fall. used to created denominator later
-        MAX(
-            CASE
-                WHEN (
-                    enrolled_in_any_college_c = true
-                    AND college_track_status_c = '15A'
-                    AND AY_Name = 'AY 2020-21'
-                    AND term_c = 'Fall'
-                ) THEN 1
-                ELSE 0
-            END
-        ) AS include_in_reporting_group,
-        --counting the # of ATs for each student in this window
-        COUNT(AT_Id) AS at_count,
-        --for those same records, counting # of ATs for each student in which they met term to term persistence definition
-        SUM(indicator_persisted_at_c) AS persist_count
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template` --Start date for PAT must be prior today to be included. To exclude future PATs upon creation, until they become current AT. want to ignore summer too.
-    WHERE
-        start_date_c < CURRENT_DATE()
-        AND(
-            (
-                AY_Name = 'AY 2020-21'
-                AND term_c <> 'Summer'
-            )
-            OR (
-                AY_Name = 'AY 2021-22'
-                AND term_c = 'Fall'
-            )
-        )
-    GROUP BY
-        contact_id
+get_persist_at_data AS
+(
+  SELECT
+    contact_id AS persist_contact_id,
+    Gender_c AS persist_contact_gender,
+    Ethnic_background_c AS persist_contact_ethnic_background,
+--indicator to flag which students were enrolled in any college last fall. used to created denominator later
+    MAX(CASE
+        WHEN
+        (enrolled_in_any_college_c = true
+        AND college_track_status_c = '15A'
+        AND AY_Name = 'AY 2020-21'
+        AND term_c = 'Fall') THEN 1
+        ELSE 0
+    END) AS include_in_reporting_group,
+--counting the # of ATs for each student in this window
+    COUNT(AT_Id) AS at_count,
+--for those same records, counting # of ATs for each student in which they met term to term persistence definition
+    SUM(indicator_persisted_at_c) AS persist_count
+
+    FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+--Start date for PAT must be prior today to be included. To exclude future PATs upon creation, until they become current AT. want to ignore summer too.
+    WHERE start_date_c < CURRENT_DATE()
+        AND((AY_Name = 'AY 2020-21'
+        AND term_c <> 'Summer')
+        OR
+        (AY_Name = 'AY 2021-22'
+        AND term_c = 'Fall'))
+    GROUP BY contact_id,
+    Gender_c,
+    Ethnic_background_c
 ),
 --actually comparing the # terms vs. # of terms meeting persistence defintion, per student
-persist_calc AS (
+persist_calc AS
+(
     SELECT
-        persist_contact_id,
-        MAX(include_in_reporting_group) AS cc_persist_denom,
-        -- if # terms = # of terms meeting persistence defintion, student will be in numerator
-        MAX(
-            CASE
-                WHEN at_count = persist_count THEN 1
-                ELSE 0
-            END
-        ) AS indicator_persisted
-    FROM
-        get_persist_at_data -- filter out any students who weren't enrolled last fall. denominator
-    WHERE
-        include_in_reporting_group = 1
-    GROUP BY
-        persist_contact_id
+    persist_contact_id,
+    persist_contact_gender,
+    persist_contact_ethnic_background,
+
+    MAX(include_in_reporting_group) AS cc_persist_denom,
+  -- if # terms = # of terms meeting persistence defintion, student will be in numerator
+    MAX(
+    CASE
+        WHEN at_count = persist_count THEN 1
+        ELSE 0
+    END) AS indicator_persisted
+    FROM get_persist_at_data
+-- filter out any students who weren't enrolled last fall. denominator
+    WHERE include_in_reporting_group = 1
+    GROUP BY persist_contact_id,
+    persist_contact_gender,
+    persist_contact_ethnic_background
 ),
 --trending alumni survey measures, using FY20 survey data that's been uploaded into BigQuery
-get_fy20_alumni_survey_data AS (
+get_fy20_alumni_survey_data AS
+(
     SELECT
-        Contact_Id AS alum_contact_id,
-        --% of graduates with meaningful employment
-        CASE
-            WHEN i_feel_my_current_job_is_meaningful IN ('Strongly Agree', "Agree") THEN 1
-            ELSE 0
-        END AS fy20_alumni_survey_meaningful_num,
-        --% of graduates meeting gainful employment standard
-        CASE
-            WHEN (
-                indicator_annual_loan_repayment_amount_current_loan_debt_125 / indicator_income_proxy
-            ) <=.08 THEN 1
-            ELSE 0
-        END AS fy20_alumni_survey_gainful_num,
-        --meaningful & gainful denom - all survey respondents
-        CASE
-            WHEN Contact_Id IS NOT NULL THEN 1
-            ELSE 0
-        END AS fy20_alumni_survey_meaningful_gainful_denom,
-        --% of graduates with full-time employment or enrolled in graduate school within 6 months of graduation 
-        CASE
-            WHEN (
-                survey_year = 'FD20'
-                AND indicator_ft_job_or_grad_school_within_6_months = 1
-            ) THEN 1
-            ELSE 0
-        END AS fy20_alumni_survey_employed_grad_6_months_num,
-        -- denom is all recent grad survey respondets (ie FD survey)
-        CASE
-            WHEN survey_year = 'FD20' THEN 1
-            ELSE 0
-        END AS fy20_alumni_survey_employed_grad_6_months_denom,
-    FROM
-        `data-warehouse-289815.surveys.fy20_alumni_survey` -- BH had one college student graduate in spring and then somehow got access / took fy20 alum survey. 
-    WHERE
-        ct_site != 'College Track Boyle Heights'
+    Contact_Id AS alum_contact_id,
+    gender AS alum_gender,
+    ethnicity AS alum_ethnic_background,
+--% of graduates with meaningful employment
+    CASE
+        WHEN i_feel_my_current_job_is_meaningful IN ('Strongly Agree', "Agree") THEN 1
+        ELSE 0
+    END AS fy20_alumni_survey_meaningful_num,
+--% of graduates meeting gainful employment standard
+    CASE
+        WHEN
+        (indicator_annual_loan_repayment_amount_current_loan_debt_125 / indicator_income_proxy) <=.08 THEN 1
+        ELSE 0
+    END AS fy20_alumni_survey_gainful_num,
+--meaningful & gainful denom - all survey respondents
+    CASE
+        WHEN Contact_Id IS NOT NULL THEN 1
+        ELSE 0
+    END AS fy20_alumni_survey_meaningful_gainful_denom,
+--% of graduates with full-time employment or enrolled in graduate school within 6 months of graduation
+    CASE
+        WHEN (survey_year = 'FD20'
+        AND indicator_ft_job_or_grad_school_within_6_months	= 1) THEN 1
+        ELSE 0
+    END AS fy20_alumni_survey_employed_grad_6_months_num,
+-- denom is all recent grad survey respondets (ie FD survey)
+    CASE
+        WHEN survey_year = 'FD20' THEN 1
+        ELSE 0
+    END AS fy20_alumni_survey_employed_grad_6_months_denom,
+
+    FROM `data-warehouse-289815.surveys.fy20_alumni_survey`
+-- BH had one college student graduate in spring and then somehow got access / took fy20 alum survey.
+    WHERE ct_site !='College Track Boyle Heights'
 ),
-join_data AS (
+join_data AS
+(
     SELECT
-        get_contact_data.*,
-        get_at_data.indicator_fafsa_complete,
-        get_at_data.indicator_loans_less_30k_loans,
-        get_at_data.indicator_well_balanced,
-        get_at_data.indicator_tech_interpersonal_skills,
-        persist_calc.indicator_persisted,
-        persist_calc.cc_persist_denom,
-        get_fy20_alumni_survey_data.fy20_alumni_survey_meaningful_num,
-        get_fy20_alumni_survey_data.fy20_alumni_survey_gainful_num,
-        get_fy20_alumni_survey_data.fy20_alumni_survey_meaningful_gainful_denom,
-        get_fy20_alumni_survey_data.fy20_alumni_survey_employed_grad_6_months_num,
-        get_fy20_alumni_survey_data.fy20_alumni_survey_employed_grad_6_months_denom,
-    FROM
-        get_contact_data
-        LEFT JOIN get_at_data ON at_contact_id = contact_id
-        LEFT JOIN persist_calc ON persist_calc.persist_contact_id = contact_id
-        LEFT JOIN get_fy20_alumni_survey_data ON get_fy20_alumni_survey_data.alum_contact_id = contact_id
+    get_contact_data.*,
+    get_at_data.indicator_fafsa_complete,
+    get_at_data.indicator_loans_less_30k_loans,
+    get_at_data.indicator_well_balanced,
+    get_at_data.indicator_tech_interpersonal_skills,
+    persist_calc.indicator_persisted,
+    persist_calc.cc_persist_denom,
+    get_fy20_alumni_survey_data.fy20_alumni_survey_meaningful_num,
+    get_fy20_alumni_survey_data.fy20_alumni_survey_gainful_num,
+    get_fy20_alumni_survey_data.fy20_alumni_survey_meaningful_gainful_denom,
+    get_fy20_alumni_survey_data.fy20_alumni_survey_employed_grad_6_months_num,
+    get_fy20_alumni_survey_data.fy20_alumni_survey_employed_grad_6_months_denom,
+
+    FROM get_contact_data
+    LEFT JOIN get_at_data ON at_contact_id = contact_id AND at_gender = Gender_c AND at_ethnic_background = Ethnic_background_c
+    LEFT JOIN persist_calc ON persist_calc.persist_contact_id = contact_id AND persist_contact_gender = Gender_c AND persist_contact_ethnic_background = Ethnic_background_c
+    LEFT JOIN get_fy20_alumni_survey_data ON get_fy20_alumni_survey_data.alum_contact_id = contact_id AND alum_gender = Gender_c AND alum_ethnic_background = Ethnic_background_c
 ),
-cc_ps AS (
+cc_ps AS
+(
     SELECT
-        site_short,
-        sum(cc_ps_projected_grad_num) AS cc_ps_projected_grad_num,
-        sum(cc_ps_projected_grad_denom) AS cc_ps_projected_grad_denom,
-        sum(x_2_yr_transfer_num) AS cc_ps_2_yr_transfer_num,
-        sum(x_2_yr_transfer_denom) AS cc_ps_2_yr_transfer_denom,
-        sum(cc_ps_grad_internship_num) AS cc_ps_grad_internship_num,
-        sum(cc_ps_grad_internship_denom) AS cc_ps_grad_internship_denom,
-        sum(cc_ps_gpa_2_5_num) AS cc_ps_gpa_2_5_num,
-        sum(indicator_loans_less_30k_loans) AS cc_ps_loans_30k,
-        sum(indicator_fafsa_complete) AS cc_ps_fasfa_complete,
-        sum(indicator_well_balanced) AS cc_ps_well_balanced_lifestyle,
-        sum(indicator_tech_interpersonal_skills) AS cc_ps_tech_interpersonal_skills,
-        sum(indicator_persisted) AS cc_ps_persist_num,
-        sum(cc_persist_denom) AS cc_persist_denom,
-        sum(fy20_alumni_survey_meaningful_num) AS cc_ps_meaningful_num,
-        sum(fy20_alumni_survey_gainful_num) AS cc_ps_gainful_num,
-        sum(fy20_alumni_survey_meaningful_gainful_denom) AS cc_ps_meaningful_gainful_denom,
-        sum(fy20_alumni_survey_employed_grad_6_months_num) AS cc_ps_employed_grad_6_months_num,
-        sum(fy20_alumni_survey_employed_grad_6_months_denom) AS cc_ps_employed_grad_6_months_denom,
-    FROM
-        join_data
-    GROUP BY
-        site_short
+    site_short,
+    Gender_c,
+    Ethnic_background_c,
+    sum(cc_ps_projected_grad_num) AS cc_ps_projected_grad_num,
+    sum(cc_ps_projected_grad_denom) AS cc_ps_projected_grad_denom,
+    sum(x_2_yr_transfer_num) AS cc_ps_2_yr_transfer_num,
+    sum(x_2_yr_transfer_denom) AS cc_ps_2_yr_transfer_denom,
+    sum(cc_ps_grad_internship_num) AS cc_ps_grad_internship_num,
+    sum(cc_ps_grad_internship_denom) AS cc_ps_grad_internship_denom,
+    sum(cc_ps_gpa_2_5_num) AS cc_ps_gpa_2_5_num,
+    sum(indicator_loans_less_30k_loans) AS cc_ps_loans_30k,
+    sum(indicator_fafsa_complete) AS cc_ps_fasfa_complete,
+    sum(indicator_well_balanced) AS cc_ps_well_balanced_lifestyle,
+    sum(indicator_tech_interpersonal_skills) AS cc_ps_tech_interpersonal_skills,
+    sum(indicator_persisted) AS cc_ps_persist_num,
+    sum(cc_persist_denom) AS cc_persist_denom,
+    sum(fy20_alumni_survey_meaningful_num) AS cc_ps_meaningful_num,
+    sum(fy20_alumni_survey_gainful_num) AS cc_ps_gainful_num,
+    sum(fy20_alumni_survey_meaningful_gainful_denom) AS cc_ps_meaningful_gainful_denom,
+    sum(fy20_alumni_survey_employed_grad_6_months_num) AS cc_ps_employed_grad_6_months_num,
+    sum(fy20_alumni_survey_employed_grad_6_months_denom) AS cc_ps_employed_grad_6_months_denom,
+
+    FROM join_data
+    GROUP BY site_short,
+    Gender_c,
+    Ethnic_background_c
 )
-SELECT
+    SELECT
     *
-FROM
+    FROM
     cc_ps

--- a/fp.sql
+++ b/fp.sql
@@ -1,170 +1,167 @@
-WITH gather_survey_data AS (
+WITH gather_survey_data AS
+(
     SELECT
-        site_short AS survey_site_short,
-        SUM(
-            CASE
-                WHEN contact_id IS NOT NULL THEN 1
-                ELSE 0
-            END
-        ) AS ps_survey_scholarship_denom,
-        SUM(
-            CASE
-                WHEN i_am_able_to_receive_my_scholarship_funds_from_college_track IN ('StronglyAgree', 'Strongly Agree', 'Agree') THEN 1
-                ELSE 0
-            END
-        ) AS ps_survey_scholarship_num
-    FROM
-        `data-studio-260217.surveys.fy21_ps_survey_wide_prepped`
-    WHERE
-        i_am_able_to_receive_my_scholarship_funds_from_college_track IS NOT NULL
-    GROUP BY
-        site_short
+    site_short AS survey_site_short,
+    Gender_c AS survey_gender,
+    Ethnic_background_c AS survey_ethnic_background,
+    SUM(
+    CASE
+        WHEN contact_id IS NOT NULL THEN 1
+        ELSE 0
+    END) AS ps_survey_scholarship_denom,
+    SUM(
+    CASE
+        WHEN i_am_able_to_receive_my_scholarship_funds_from_college_track IN ('StronglyAgree', 'Strongly Agree', 'Agree') THEN 1
+        ELSE 0
+    END) AS ps_survey_scholarship_num
+
+    FROM  `data-studio-260217.surveys.fy21_ps_survey_wide_prepped`
+    WHERE i_am_able_to_receive_my_scholarship_funds_from_college_track IS NOT NULL
+    GROUP BY site_short,
+    Gender_c,
+    Ethnic_background_c
 ),
-get_at_data AS (
+
+get_at_data AS
+(
     SELECT
-        site_short AS at_site,
-        --% of college students saying that they know how to apply for Emergency Fund in PAT advising rubric
-        SUM(
-            CASE
-                WHEN e_fund_c = 'EF_G' THEN 1
-                ELSE 0
-            END
-        ) AS indicator_efund,
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template`
-    WHERE
-        college_track_status_c = '15A' -- dates are used as part of filter here to handle the switch from spring AT to summer. 
-        AND(
-            (
-                CURRENT_DATE() < '2021-07-01'
-                AND current_as_c = TRUE
-            )
-            OR (
-                CURRENT_DATE() > '2021-07-01'
-                AND previous_as_c = TRUE
-            )
-        )
-    GROUP BY
-        site_short
+    site_short AS at_site,
+    Gender_c AS at_gender,
+    Ethnic_background_c AS at_ethnic_background,
+--% of college students saying that they know how to apply for Emergency Fund in PAT advising rubric
+    SUM(
+    CASE
+        WHEN e_fund_c = 'EF_G' THEN 1
+        ELSE 0
+    END) AS indicator_efund,
+
+    FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+    WHERE college_track_status_c = '15A'
+-- dates are used as part of filter here to handle the switch from spring AT to summer.
+    AND(
+    (CURRENT_DATE() < '2021-07-01'
+    AND current_as_c = TRUE)
+    OR
+    (CURRENT_DATE() > '2021-07-01'
+    AND previous_as_c = TRUE))
+    GROUP BY site_short,
+    Gender_c,
+    Ethnic_background_c
 ),
-/*get_first_year_loan_debt AS
- (
- SELECT
- AT_Id,
- Contact_Id AS year_1_spring_contact_id,
- site_short AS year_1_spring_AT_site,
- CASE
- WHEN 
- 
- FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
- WHERE college_track_status_c = '15A'
- */
-gather_contact_data AS (
-    --% of high school seniors with EFC by end of March. Right now we are not accounting for the timebound part as we don't currently have a way to track when it was completed. 
+
+gather_contact_data AS
+(
+--% of high school seniors with EFC by end of March. Right now we are not accounting for the timebound part as we don't currently have a way to track when it was completed.
     SELECT
-        site_short,
-        SUM(
-            CASE
-                WHEN fa_req_expected_financial_contribution_c IS NOT NULL THEN 1
-                ELSE 0
-            END
-        ) AS fp_12_efc_num
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template`
-    WHERE
-        college_track_status_c = '11A'
-        AND (
-            grade_c = "12th Grade"
-            OR (
-                grade_c = 'Year 1'
-                AND indicator_years_since_hs_graduation_c = 0
-            )
-        )
-    GROUP BY
-        site_short
+    site_short,
+    Gender_c AS contact_gender,
+    Ethnic_background_c AS contact_ethnic_background,
+    SUM(
+    CASE
+        WHEN (college_track_status_c = '11A'
+        AND (grade_c = "12th Grade" OR (grade_c='Year 1' AND indicator_years_since_hs_graduation_c = 0))
+        AND fa_req_expected_financial_contribution_c IS NOT NULL) THEN 1
+        ELSE 0
+    END) AS fp_12_efc_num
+    FROM `data-warehouse-289815.salesforce_clean.contact_template`
+    WHERE college_track_status_c IN ('11A', '12A', '15A')
+    GROUP BY site_short,
+    Gender_c,
+    Ethnic_background_c
 ),
+
 --For KPI % of students admitted to Best-Fit College choose to enroll at Best-Fit College
 gather_best_fit_data AS (
     SELECT
         contact_id,
         site_short,
-        --Students accepted to Best Fit
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq1
-            WHERE
-                (
-                    admission_status_c = "Accepted"
-                    AND College_Fit_Type_Applied_c = "Best Fit"
-                )
-                AND Contact_Id = student_c
-            group by
-                student_c
+        Gender_c AS bf_gender,
+        Ethnic_background_c AS bf_ethnic_background,
+
+    --Students accepted to Best Fit
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq1
+        WHERE (admission_status_c = "Accepted" AND College_Fit_Type_Applied_c = "Best Fit")
+        AND Contact_Id=student_c
+        group by student_c
         ) AS accepted_best_fit,
-        --Students enrolled in Best Fit
-        (
-            SELECT
-                student_c
-            FROM
-                `data-warehouse-289815.salesforce_clean.college_application_clean` AS subq2
-            WHERE
-                admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred")
-                AND fit_type_enrolled_c = "Best Fit"
-                AND Contact_Id = student_c
-            group by
-                student_c
+
+    --Students enrolled in Best Fit
+        (SELECT student_c
+        FROM `data-warehouse-289815.salesforce_clean.college_application_clean`AS subq2
+        WHERE admission_status_c IN ("Accepted and Enrolled", "Accepted and Deferred") AND fit_type_enrolled_c = "Best Fit"
+        AND Contact_Id=student_c
+        group by student_c
         ) AS accepted_enrolled_best_fit
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_template`
-    WHERE
-        college_track_status_c = '11A'
-        AND (
-            grade_c = "12th Grade"
-            OR (
-                grade_c = 'Year 1'
-                AND indicator_years_since_hs_graduation_c = 0
-            )
-        )
+
+    FROM `data-warehouse-289815.salesforce_clean.contact_template`
+    WHERE  college_track_status_c = '11A'
+    AND (grade_c = "12th Grade" OR (grade_c='Year 1' AND indicator_years_since_hs_graduation_c = 0))
 ),
+
 --Define numerator and denominator for KPI % of students admitted to Best-Fit College enroll at Best-Fit College
 prep_best_fit_enrollment_kpi AS (
-    SELECT
-        site_short,
-        SUM(
-            CASE
-                WHEN accepted_best_fit IS NOT NULL THEN 1
-                ELSE 0
-            END
-        ) AS fp_accepted_best_fit_denom,
-        SUM(
-            CASE
-                WHEN accepted_enrolled_best_fit IS NOT NULL THEN 1
-                ELSE 0
-            END
-        ) AS fp_enrolled_best_fit_numerator,
-    FROM
-        gather_best_fit_data
-    GROUP BY
-        site_short
-),
-join_data AS (
-    SELECT
-        a.site_short,
-        fp_12_efc_num AS fp_12_efc_num,
-        gather_survey_data.ps_survey_scholarship_denom,
-        gather_survey_data.ps_survey_scholarship_num,
-        get_at_data.indicator_efund AS fp_efund_num,
-        fp_accepted_best_fit_denom,
-        fp_enrolled_best_fit_numerator
-    FROM
-        gather_contact_data AS a
-        LEFT JOIN gather_survey_data ON gather_survey_data.survey_site_short = site_short
-        LEFT JOIN get_at_data ON get_at_data.at_site = site_short
-        LEFT JOIN prep_best_fit_enrollment_kpi AS prep_best_fit_enrollment_kpi ON prep_best_fit_enrollment_kpi.site_short = a.site_short
-)
 SELECT
+    site_short AS bf_site_short,
+    bf_gender,
+    bf_ethnic_background,
+    SUM(CASE
+        WHEN accepted_best_fit IS NOT NULL
+        THEN 1
+        ELSE 0
+    END) AS fp_accepted_best_fit_denom,
+
+    SUM(CASE
+        WHEN accepted_enrolled_best_fit IS NOT NULL
+        THEN 1
+        ELSE 0
+    END) AS fp_enrolled_best_fit_numerator,
+
+FROM gather_best_fit_data
+GROUP BY site_short,
+bf_gender,
+bf_ethnic_background
+),
+
+join_data AS
+(
+    SELECT
+    a.site_short AS fp_site_short,
+    a.contact_gender AS fp_gender,
+    a.contact_ethnic_background AS fp_ethnic_background,
+    fp_12_efc_num AS fp_12_efc_num,
+    gsd.ps_survey_scholarship_denom,
+    gsd.ps_survey_scholarship_num,
+    cat.indicator_efund AS fp_efund_num,
+    fp_accepted_best_fit_denom,
+    fp_enrolled_best_fit_numerator
+
+
+    FROM gather_contact_data AS a
+    LEFT JOIN gather_survey_data AS gsd ON gsd.survey_site_short = a.site_short AND gsd.survey_gender = a.contact_gender AND gsd.survey_ethnic_background = a.contact_ethnic_background
+    LEFT JOIN get_at_data AS cat ON cat.at_site = a.site_short AND cat.at_gender = a.contact_gender AND cat.at_ethnic_background = a.contact_ethnic_background
+    LEFT JOIN prep_best_fit_enrollment_kpi AS bfp ON bfp.bf_site_short=a.site_short AND bfp.bf_gender = a.contact_gender AND bfp.bf_ethnic_background = a.contact_ethnic_background
+),
+
+fp AS
+(
+    SELECT
+    fp_site_short,
+    fp_gender,
+    fp_ethnic_background,
+    SUM(fp_12_efc_num) AS fp_12_efc_num,
+    SUM(ps_survey_scholarship_denom) AS ps_survey_scholarship_denom,
+    SUM(ps_survey_scholarship_num) AS ps_survey_scholarship_num,
+    SUM(fp_efund_num) AS fp_efund_num,
+    SUM(fp_accepted_best_fit_denom) AS fp_accepted_best_fit_denom,
+    SUM(fp_enrolled_best_fit_numerator) AS fp_enrolled_best_fit_numerator
+    FROM join_data
+    WHERE fp_site_short NOT IN ('The Durant Center', 'Ward 8', 'Crenshaw')
+    GROUP BY fp_site_short,
+    fp_gender,
+    fp_ethnic_background
+)
+
+    SELECT
     *
-FROM
-    join_data
+    FROM fp

--- a/gather_all_team_data.sql
+++ b/gather_all_team_data.sql
@@ -9,28 +9,28 @@ join_team_kpis AS (
     JP.*,
     AA.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
     SD.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
-    -- SL.* EXCEPT(site_short),
-    -- CC_HS.* EXCEPT(site_short),
-    -- CC_PS.* EXCEPT(site_short),
+    SL.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    CC_HS.* EXCEPT(site_short,Ethnic_background_c, Gender_c),
+    CC_PS.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
     OM.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
     RED.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
     PRO_OPS.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
-    OM_ATTEND.* EXCEPT(site_short, Ethnic_background_c, Gender_c)
-    -- WLLNSS.* EXCEPT(site_short),
-    -- FP.* EXCEPT(site_short)
+    OM_ATTEND.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    WLLNSS.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    FP.* EXCEPT(site_short, Ethnic_background_c, Gender_c)
   FROM
     join_prep JP
     LEFT JOIN `data-studio-260217.kpi_dashboard.academic_affairs` AA ON AA.site_short = JP.site_short AND AA.Ethnic_background_c = JP.Ethnic_background_c AND AA.Gender_c = JP.Gender_c
     LEFT JOIN `data-studio-260217.kpi_dashboard_dev.site_directors` SD ON SD.site_short = JP.site_short AND SD.Ethnic_background_c = JP.Ethnic_background_c AND SD.Gender_c = JP.Gender_c
-    -- LEFT JOIN `data-studio-260217.kpi_dashboard.cc_hs` CC_HS ON CC_HS.site_short = JP.site_short
-    -- LEFT JOIN `data-studio-260217.kpi_dashboard.cc_ps` CC_PS ON CC_PS.site_short = JP.site_short
-    -- LEFT JOIN `data-studio-260217.kpi_dashboard.student_life` SL ON SL.site_short = JP.site_short
+    LEFT JOIN `data-studio-260217.kpi_dashboard.cc_hs` CC_HS ON CC_HS.site_short = JP.site_short AND CC_HS.Ethnic_background_c = JP.Ethnic_background_c AND CC_HS.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.cc_ps` CC_PS ON CC_PS.site_short = JP.site_short AND CC_PS.Ethnic_background_c = JP.Ethnic_background_c AND CC_PS.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.student_life` SL ON SL.site_short = JP.site_short AND SL.Ethnic_background_c = JP.Ethnic_background_c AND SL.Gender_c = JP.Gender_c
     LEFT JOIN `data-studio-260217.kpi_dashboard.om` OM ON OM.site_short = JP.site_short AND OM.Ethnic_background_c = JP.Ethnic_background_c AND OM.Gender_c = JP.Gender_c
     LEFT JOIN `data-studio-260217.kpi_dashboard.red`RED ON RED.site_short = JP.site_short AND RED.Ethnic_background_c = JP.Ethnic_background_c AND RED.Gender_c = JP.Gender_c
     LEFT JOIN `data-studio-260217.kpi_dashboard.program_ops` PRO_OPS ON PRO_OPS.site_short = JP.site_short AND PRO_OPS.Ethnic_background_c = JP.Ethnic_background_c AND PRO_OPS.Gender_c = JP.Gender_c
     LEFT JOIN `data-studio-260217.kpi_dashboard.om_incomplete_attendance` OM_ATTEND ON OM_ATTEND.site_short = JP.site_short AND OM_ATTEND.Ethnic_background_c = JP.Ethnic_background_c AND OM_ATTEND.Gender_c = JP.Gender_c
-    -- LEFT JOIN `data-studio-260217.kpi_dashboard.wellness` WLLNSS ON WLLNSS.site_short = JP.site_short
-    -- LEFT JOIN `data-studio-260217.kpi_dashboard.fp` FP ON FP.site_short = JP.site_short
+    LEFT JOIN `data-studio-260217.kpi_dashboard.wellness` WLLNSS ON WLLNSS.site_short = JP.site_short AND WLLNSS.Ethnic_background_c = JP.Ethnic_background_c AND WLLNSS.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.fp` FP ON FP.site_short = JP.site_short AND FP.Ethnic_background_c = JP.Ethnic_background_c AND FP.Gender_c = JP.Gender_c
 
 )
 SELECT

--- a/gather_all_team_data.sql
+++ b/gather_all_team_data.sql
@@ -2,35 +2,35 @@ WITH join_prep AS (
   SELECT
     *
   FROM
-    `data-studio-260217.kpi_dashboard.join_prep`
+    `data-studio-260217.kpi_dashboard_dev.join_prep`
 ),
 join_team_kpis AS (
   SELECT
     JP.*,
-    AA.* EXCEPT(site_short),
-    SD.* EXCEPT(site_short),
-    SL.* EXCEPT(site_short),
-    CC_HS.* EXCEPT(site_short),
-    CC_PS.* EXCEPT(site_short),
-    OM.* EXCEPT(site_short),
-    RED.* EXCEPT(site_short),
-    PRO_OPS.* EXCEPT(site_short),
-    OM_ATTEND.* EXCEPT(site_short),
-    WLLNSS.* EXCEPT(site_short),
-    FP.* EXCEPT(site_short)
+    AA.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    SD.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    -- SL.* EXCEPT(site_short),
+    -- CC_HS.* EXCEPT(site_short),
+    -- CC_PS.* EXCEPT(site_short),
+    OM.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    RED.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    PRO_OPS.* EXCEPT(site_short, Ethnic_background_c, Gender_c),
+    OM_ATTEND.* EXCEPT(site_short, Ethnic_background_c, Gender_c)
+    -- WLLNSS.* EXCEPT(site_short),
+    -- FP.* EXCEPT(site_short)
   FROM
     join_prep JP
-    LEFT JOIN `data-studio-260217.kpi_dashboard.academic_affairs` AA ON AA.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.site_directors` SD ON SD.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.cc_hs` CC_HS ON CC_HS.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.cc_ps` CC_PS ON CC_PS.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.student_life` SL ON SL.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.om` OM ON OM.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.red`RED ON RED.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.program_ops` PRO_OPS ON PRO_OPS.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.om_incomplete_attendance` OM_ATTEND ON OM_ATTEND.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.wellness` WLLNSS ON WLLNSS.site_short = JP.site_short
-    LEFT JOIN `data-studio-260217.kpi_dashboard.fp` FP ON FP.site_short = JP.site_short
+    LEFT JOIN `data-studio-260217.kpi_dashboard.academic_affairs` AA ON AA.site_short = JP.site_short AND AA.Ethnic_background_c = JP.Ethnic_background_c AND AA.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard_dev.site_directors` SD ON SD.site_short = JP.site_short AND SD.Ethnic_background_c = JP.Ethnic_background_c AND SD.Gender_c = JP.Gender_c
+    -- LEFT JOIN `data-studio-260217.kpi_dashboard.cc_hs` CC_HS ON CC_HS.site_short = JP.site_short
+    -- LEFT JOIN `data-studio-260217.kpi_dashboard.cc_ps` CC_PS ON CC_PS.site_short = JP.site_short
+    -- LEFT JOIN `data-studio-260217.kpi_dashboard.student_life` SL ON SL.site_short = JP.site_short
+    LEFT JOIN `data-studio-260217.kpi_dashboard.om` OM ON OM.site_short = JP.site_short AND OM.Ethnic_background_c = JP.Ethnic_background_c AND OM.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.red`RED ON RED.site_short = JP.site_short AND RED.Ethnic_background_c = JP.Ethnic_background_c AND RED.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.program_ops` PRO_OPS ON PRO_OPS.site_short = JP.site_short AND PRO_OPS.Ethnic_background_c = JP.Ethnic_background_c AND PRO_OPS.Gender_c = JP.Gender_c
+    LEFT JOIN `data-studio-260217.kpi_dashboard.om_incomplete_attendance` OM_ATTEND ON OM_ATTEND.site_short = JP.site_short AND OM_ATTEND.Ethnic_background_c = JP.Ethnic_background_c AND OM_ATTEND.Gender_c = JP.Gender_c
+    -- LEFT JOIN `data-studio-260217.kpi_dashboard.wellness` WLLNSS ON WLLNSS.site_short = JP.site_short
+    -- LEFT JOIN `data-studio-260217.kpi_dashboard.fp` FP ON FP.site_short = JP.site_short
 
 )
 SELECT

--- a/om.sql
+++ b/om.sql
@@ -1,6 +1,8 @@
 WITH gather_survey_data AS (
   SELECT
     CT.site_short,
+      CT.Ethnic_background_c,
+      CT.Gender_c,
     S.contact_id,
     -- % of students that agree or strongly agree to 'my site is run effectively'
     -- The denominator for this metric is housed in the join_prep query.
@@ -18,8 +20,14 @@ WITH gather_survey_data AS (
 
 SELECT
   GSD.site_short,
+    GSD.Ethnic_background_c,
+    GSD.Gender_c,
   SUM(GSD.agree_site_is_run_effectively) AS OM_agree_site_is_run_effectively
 from
   gather_survey_data GSD
+WHERE site_short IS NOT NULL
 GROUP BY
-  GSD.site_short
+  GSD.site_short,
+             GSD.Ethnic_background_c,
+    GSD.Gender_c
+

--- a/om_attendance_reconcile.sql
+++ b/om_attendance_reconcile.sql
@@ -2,6 +2,8 @@
 -- This will be a unique query. It will only run on the 5th of each month and pull data from the previous month or earlier. It will just count the number of WSA records that are still scheduled.
 SELECT
   site_short,
+  Ethnic_background_c,
+  Gender_c,
   COUNT(Class_Attendance_Id) AS OM_incomplete_wsa_records
 FROM
   `data-warehouse-289815.salesforce_clean.class_template` CT
@@ -22,4 +24,6 @@ WHERE
   AND current_as_c = true
   AND is_deleted = false
 GROUP BY
-  site_short
+  site_short,
+    Ethnic_background_c,
+    Gender_c

--- a/program_ops.sql
+++ b/program_ops.sql
@@ -1,75 +1,69 @@
 WITH gather_data AS (
-  SELECT
-    Contact_Id,
-    site_short,
-    -- All sites admit cohorts that meet X% low-income, X% first-generation, and X% male demographic metrics.
-    -- The denominator for these metrics is calculated in join_prep
-    CASE
-      WHEN grade_c = '9th Grade'
-      AND (indicator_first_generation_c = true) THEN 1
-      ELSE 0
-    END AS incoming_cohort_first_gen,
-    CASE
-      WHEN grade_c = '9th Grade'
-      AND (indicator_low_income_c = 'Yes') THEN 1
-      ELSE 0
-    END AS incoming_cohort_low_income,
-  FROM
-    `data-warehouse-289815.salesforce_clean.contact_template`
-  WHERE
-    college_track_status_c = '11A'
+    SELECT
+        Contact_Id,
+        site_short,
+        Ethnic_background_c,
+        Gender_c,
+        -- All sites admit cohorts that meet X% low-income, X% first-generation, and X% male demographic metrics.
+        -- The denominator for these metrics is calculated in join_prep
+        CASE
+            WHEN grade_c = '9th Grade'
+                AND indicator_first_generation_c = TRUE
+                AND college_track_status_c = '11A' THEN 1
+            ELSE 0
+            END AS incoming_cohort_first_gen,
+        CASE
+            WHEN grade_c = '9th Grade'
+                AND (indicator_low_income_c = 'Yes')
+                AND college_track_status_c = '11A' THEN 1
+            ELSE 0
+            END AS incoming_cohort_low_income,
+    FROM `data-warehouse-289815.salesforce_clean.contact_template`
+    WHERE college_track_status_c IN ('11A', '12A', '13A', '15A', '16A', '17A')
 ),
 -- High school NPS score from student survey
--- This is done over two CTEs, but the first one contains most of the logic
-gather_survey_data AS (
-  SELECT
-    CT.site_short,
-    S.contact_id,
-    CASE
-      WHEN (
-        how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get = '10 - extremely likely'
-        OR how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get = '9'
-      ) THEN 1
-      ELSE 0
-    END AS nps_promoter,
-    CASE
-      WHEN (
-        how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '10 - extremely likely'
-        AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '9'
-        AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '8'
-        AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '7'
-      ) THEN 1
-      ELSE 0
-    END AS nps_detractor
-  FROM
-    `data-studio-260217.surveys.fy21_hs_survey` S
-    LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_template` CT ON CT.Contact_Id = S.contact_id
-),
+     gather_survey_data AS (
+         SELECT
+             S.contact_id,
+             CASE
+                 WHEN (
+                             how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get =
+                             '10 - extremely likely'
+                         OR how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get = '9'
+                     ) THEN 1
+                 ELSE 0
+                 END AS nps_promoter,
+             CASE
+                 WHEN (
+                             how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get !=
+                             '10 - extremely likely'
+                         AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '9'
+                         AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '8'
+                         AND how_likely_are_you_to_recommend_college_track_to_a_student_who_wants_to_get != '7'
+                     ) THEN 1
+                 ELSE 0
+                 END AS nps_detractor
+         FROM `data-studio-260217.surveys.fy21_hs_survey` S
+     ),
 
-aggregate_survey_data AS (
-SELECT 
-  site_short,
-  SUM(nps_promoter) AS nps_promoter,
-  SUM(nps_detractor)AS nps_detractor
-  FROM gather_survey_data
-  GROUP BY site_short
-),
+     aggregate_metrics AS (SELECT
+                               GD.site_short,
+                               GD.Ethnic_background_c,
+                               GD.Gender_c,
+                               SUM(incoming_cohort_first_gen) AS pro_ops_incoming_cohort_first_gen,
+                               SUM(incoming_cohort_low_income) AS pro_ops_incoming_cohort_low_income,
+                               SUM(nps_promoter) AS nps_promoter,
+                               SUM(nps_detractor) AS nps_detractor
 
-aggregate_metrics AS (SELECT
-  gather_data.site_short,
-  SUM(incoming_cohort_first_gen) AS pro_ops_incoming_cohort_first_gen,
-  SUM(incoming_cohort_low_income) AS pro_ops_incoming_cohort_low_income,
+                           FROM gather_data GD
+                                LEFT JOIN gather_survey_data GSD ON GSD.contact_id = GD.Contact_Id
+                           GROUP BY GD.site_short,
+                                    GD.Ethnic_background_c,
+                                    GD.Gender_c
+     )
 
- 
-  
-FROM
-  gather_data
-GROUP BY
-  gather_data.site_short
-  )
-  
-  SELECT aggregate_metrics.*,
-  aggregate_survey_data.* EXCEPT(site_short)
-  
-  FROM aggregate_metrics
-  LEFT JOIN aggregate_survey_data ON aggregate_survey_data.site_short = aggregate_metrics.site_short
+SELECT *
+FROM aggregate_metrics
+
+
+

--- a/red.sql
+++ b/red.sql
@@ -2,89 +2,81 @@ WITH gather_data AS (
     SELECT
         Contact_Id,
         site_short,
+        Ethnic_background_c,
         -- % of seniors with GPA 3.25+ AND Composite Ready
         -- Will need to update this to be more dynamic to account for lag in GPA entry.
         CASE
             WHEN (
-                Prev_AT_Cum_GPA >= 3.25
-                AND contact_official_test_prep_withdrawal IS NULL
-                AND composite_readiness_most_recent_c = '1. Ready'
-                AND college_track_status_c = '11A'
-                AND (
-                    grade_c = "12th Grade"
-                    OR (
-                        grade_c = 'Year 1'
-                        AND indicator_years_since_hs_graduation_c = 0
-                    )
-                )
-            ) THEN 1
+                    Prev_AT_Cum_GPA >= 3.25
+                    AND contact_official_test_prep_withdrawal IS NULL
+                    AND composite_readiness_most_recent_c = '1. Ready'
+                    AND college_track_status_c = '11A'
+                    AND (
+                            grade_c = "12th Grade"
+                            OR (
+                                    grade_c = 'Year 1'
+                                    AND indicator_years_since_hs_graduation_c = 0
+                                )
+                        )
+                ) THEN 1
             ELSE 0
-        END AS gpa_3_25__test_ready,
+            END AS gpa_3_25__test_ready,
         -- % of juniors with GPA 3.25+ AND Composite Ready eleventh proxy
         -- Will need to update this to be more dynamic to account for lag in GPA entry.
         CASE
             WHEN (
-                Prev_AT_Cum_GPA >= 3.25
-                AND composite_readiness_most_recent_c = '1. Ready'
-                AND college_track_status_c = '11A'
-                AND (
-                    grade_c = "11th Grade"
-                )
-            ) THEN 1
+                    Prev_AT_Cum_GPA >= 3.25
+                    AND composite_readiness_most_recent_c = '1. Ready'
+                    AND college_track_status_c = '11A'
+                    AND (
+                        grade_c = "11th Grade"
+                        )
+                ) THEN 1
             ELSE 0
-        END AS gpa_3_25__test_ready_eleventh,
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template`
-    WHERE
-        current_as_c = true
-        AND college_track_status_c IN ('11A')
+            END AS gpa_3_25__test_ready_eleventh,
+    FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+    WHERE current_as_c = TRUE
+      AND college_track_status_c IN ('11A', '12A', '13A', '15A', '16A', '17A')
 ),
-aggregate_metrics AS (
-    SELECT
-        GD.site_short,
-        SUM(GD.gpa_3_25__test_ready) AS red_gpa_3_25_test_ready,
-        SUM(GD.gpa_3_25__test_ready_eleventh) AS red_gpa_3_25__test_ready_eleventh
-    FROM
-        gather_data GD
-    GROUP BY
-        GD.site_short
-),
+
 -- % of high school students retained annually 
--- Done over two CTEs. The main logic is housed in the first one though. 
-gather_retention_data AS (
-    SELECT
-        DISTINCT CT.student_c,
-        CASE
-            WHEN college_track_status_c IN ('11A', '18a', '12A') THEN 1
-            ELSE 0
-        END AS currently_active,
-        site_short
-    FROM
-        `data-warehouse-289815.salesforce_clean.class_template` CT
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.AT_Id = CT.Academic_Semester_c
-    WHERE
-        Attendance_Numerator_c > 0
-        AND dosage_types_c NOT LIKE '%NSO%'
-        AND AY_Name = "AY 2020-21"
-        AND grade_c != '8th Grade'
-        AND Outcome_c != 'Cancelled'
-),
-aggregate_retention_data AS (
-    SELECT
-        site_short,
-        COUNT(student_c) AS retention_denom,
-        SUM(currently_active) AS retention_num
-    FROM
-        gather_retention_data
-    GROUP BY
-        site_short
-)
-SELECT
-    AM.site_short,
-    AM.red_gpa_3_25_test_ready,
-    AM.red_gpa_3_25__test_ready_eleventh,
-    ARD.retention_denom,
-    ARD.retention_num
-FROM
-    aggregate_metrics AM
-    LEFT JOIN aggregate_retention_data ARD ON ARD.site_short = AM.site_short
+-- Done over two CTEs. The main logic is housed in the first one though.
+-- MANUAL UPDATE REQUIRED
+     gather_retention_data AS (
+         SELECT DISTINCT
+             CT.student_c,
+             CAT.Ethnic_background_c,
+             CAT.Gender_c,
+             CASE
+                 WHEN college_track_status_c IN ('11A', '18a', '12A') THEN 1
+                 ELSE 0
+                 END AS currently_active,
+             site_short
+         FROM `data-warehouse-289815.salesforce_clean.class_template` CT
+              LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT
+                        ON CAT.AT_Id = CT.Academic_Semester_c
+         WHERE Attendance_Numerator_c > 0
+           AND dosage_types_c NOT LIKE '%NSO%'
+           AND AY_Name = "AY 2020-21"
+           AND grade_c != '8th Grade'
+           AND Outcome_c != 'Cancelled'
+     ),
+     aggregate_data AS (
+         SELECT
+             GRD.site_short,
+             GRD.Ethnic_background_c,
+             GRD.Gender_c,
+             COUNT(GRD.student_c) AS retention_denom,
+             SUM(GRD.currently_active) AS retention_num,
+             SUM(GD.gpa_3_25__test_ready) AS red_gpa_3_25_test_ready,
+             SUM(GD.gpa_3_25__test_ready_eleventh) AS red_gpa_3_25__test_ready_eleventh
+
+
+         FROM gather_retention_data GRD
+              LEFT JOIN gather_data GD ON GD.contact_id = GRD.student_c
+         GROUP BY GRD.site_short,
+                  GRD.Ethnic_background_c,
+                  GRD.Gender_c
+     )
+SELECT *
+FROM aggregate_data

--- a/site_directors.sql
+++ b/site_directors.sql
@@ -3,6 +3,8 @@ WITH gather_hs_data AS (
     Contact_Id,
     site_short,
     site_c,
+    Ethnic_background_c,
+    Gender_c,
     -- % of seniors with GPA 3.25+
     -- The denominator for this is created in join_prep
     CASE
@@ -63,7 +65,9 @@ gather_ps_count_no_gap_year AS (
     site_c,
     credit_accumulation_pace_c,
     current_enrollment_status_c,
-    college_track_status_c
+    college_track_status_c,
+    Ethnic_background_c,
+    Gender_c
   FROM
     `data-warehouse-289815.salesforce_clean.contact_at_template`
   WHERE
@@ -75,17 +79,23 @@ gather_ps_count_no_gap_year AS (
 prep_on_track_denom AS (
   SELECT
     site_short,
+    Ethnic_background_c,
+    Gender_c,
     COUNT(Contact_Id) AS on_track_student_count
   FROM
     gather_ps_count_no_gap_year
   GROUP BY
-    site_short
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
 prep_on_track_data AS (
   SELECT
     Contact_Id,
     site_short,
     site_c,
+    Ethnic_background_c,
+    Gender_c,
     -- % of students with enough credits accumulated to graduate in 6 years
     -- The denominator for this is created in join_prep
     CASE
@@ -128,6 +138,8 @@ join_hs_data AS (
 prep_hs_metrics AS (
   SELECT
     GSD.site_short,
+    GSD.Ethnic_background_c,
+    GSD.Gender_c,
     COUNT(GSD.contact_id) AS SD_hs_capacity_numerator,
     SUM(above_325_gpa) AS SD_senior_above_325,
     SUM(above_325_gpa_eleventh_grade) AS SD_above_325_gpa_eleventh_grade,
@@ -140,16 +152,22 @@ prep_hs_metrics AS (
     join_hs_data GSD
     LEFT JOIN `data-warehouse-289815.salesforce.account` Account ON Account.Id = GSD.site_c
   GROUP BY
-    site_short
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
 prep_ps_metrics AS (
   SELECT
     site_short,
+    Ethnic_background_c,
+    Gender_c,
     SUM(on_track) AS SD_on_track
   FROM
     prep_on_track_data
   GROUP BY
-    site_short
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
 -- % of students growing toward average or above cialcial-emotional strengths
 -- This KPI is done over four CTEs (could probaly be made more efficient). The majority of the logic is done in the second CTE.
@@ -158,6 +176,8 @@ gather_covi_data AS (
     contact_name_c,
     site_short,
     AY_Name,
+    Ethnic_background_c,
+    Gender_c,
     MIN(
       belief_in_self_raw_score_c + engaged_living_raw_score_c + belief_in_others_raw_score_c + emotional_competence_raw_score_c
     ) AS covi_raw_score
@@ -171,7 +191,9 @@ gather_covi_data AS (
   GROUP BY
     site_short,
     contact_name_c,
-    AY_Name
+    AY_Name,
+    Ethnic_background_c,
+    Gender_c
   ORDER BY
     site_short,
     contact_name_c,
@@ -180,6 +202,8 @@ gather_covi_data AS (
 calc_covi_growth AS (
   SELECT
     site_short,
+    Ethnic_background_c,
+    Gender_c,
     contact_name_c,
     covi_raw_score - lag(covi_raw_score) over (
       partition by contact_name_c
@@ -192,6 +216,8 @@ calc_covi_growth AS (
 determine_covi_indicators AS (
   SELECT
     site_short,
+    Ethnic_background_c,
+    Gender_c,
     contact_name_c,
     CASE
       WHEN covi_growth > 0 THEN 1
@@ -205,24 +231,33 @@ determine_covi_indicators AS (
 aggregate_covi_data AS (
   SELECT
     site_short,
+    Ethnic_background_c,
+    Gender_c,
     SUM(covi_student_grew) AS SD_covi_student_grew,
     COUNT(contact_name_c) AS SD_covi_denominator
   FROM
     determine_covi_indicators
   GROUP BY
-    site_short
-)
-SELECT
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+),
+join_metrics AS (SELECT
   HS_Data.*,
   PS_Data.*
-EXCEPT
-  (site_short),
-  aggregate_covi_data.*
-EXCEPT
-  (site_short),
-  POTD.on_track_student_count AS SD_on_track_student_count
+EXCEPT(site_short,Ethnic_background_c,
+    Gender_c),
+aggregate_covi_data.* EXCEPT (site_short,Ethnic_background_c,
+    Gender_c),
+POTD.on_track_student_count AS SD_on_track_student_count,
+-- GCM.hs_cohort_capacity
 FROM
   prep_hs_metrics HS_Data
-  LEFT JOIN prep_ps_metrics PS_Data ON PS_Data.site_short = HS_Data.site_short
-  LEFT JOIN aggregate_covi_data ON aggregate_covi_data.site_short = HS_Data.site_short
-  LEFT JOIN prep_on_track_denom POTD ON POTD.site_short = HS_Data.site_short
+  LEFT JOIN prep_ps_metrics PS_Data ON PS_Data.site_short = HS_Data.site_short AND PS_Data.Gender_c = HS_Data.Gender_c AND HS_Data.Ethnic_background_c = PS_Data.Ethnic_background_c
+  LEFT JOIN aggregate_covi_data ON aggregate_covi_data.site_short = HS_Data.site_short AND aggregate_covi_data.Gender_c = HS_Data.Gender_c AND aggregate_covi_data.Ethnic_background_c = HS_Data.Ethnic_background_c
+  LEFT JOIN prep_on_track_denom POTD ON POTD.site_short = HS_Data.site_short AND POTD.Gender_c = HS_Data.Gender_c AND POTD.Ethnic_background_c = HS_Data.Ethnic_background_c
+--   LEFT JOIN gather_capacity_metrics GCM ON GCM.site_short = HS_Data.site_short
+ )
+
+ SELECT *
+ FROM join_metrics

--- a/student_life.sql
+++ b/student_life.sql
@@ -1,11 +1,3 @@
-/*
- CREATE OR REPLACE TABLE `data-studio-260217.kpi_dashboard.student_life` 
- OPTIONS
- (
- description= "Aggregating Student Life KPI metrics for the Data Studio KPI dashboard"
- )
- AS
- */
 WITH gather_contact_data AS(
     SELECT
         contact_id,
@@ -18,39 +10,35 @@ WITH gather_contact_data AS(
                 AND college_track_status_c = '11A'
             ) THEN 1
             ELSE 0
-        END AS dream_declared
+        END AS dream_declared,
+        Ethnic_background_c,
+        Gender_c
     FROM
         `data-warehouse-289815.salesforce_clean.contact_template` AS C
-    WHERE
-        (
-            college_track_status_c = '11A'
-            OR indicator_completed_ct_hs_program_c = TRUE
-        )
 ),
---pull in students that have at least 1 workshop attendance session
---this indicates some threshold of participation in programming, even if attendance numerator < 1
+
 mse_reporting_group AS (
-    SELECT
+      SELECT
         student_c,
         site_short,
-        SUM(
+    SUM(
             CASE
-                WHEN student_audit_status_c = 'Current CT HS Student' THEN 1
-                ELSE 0
-            END
-        ) AS current_at_count,
+            WHEN student_audit_status_c = 'Current CT HS Student' THEN 1
+            ELSE 0
+        END) AS current_at_count,
+        Ethnic_background_c,
+        Gender_c
     FROM
         `data-warehouse-289815.salesforce_clean.contact_at_template`
     WHERE
-        --CT Status (AT) = Current CT HS Student during Spring 2019-20 AND Summer 2019-20
-        GAS_Name IN (
-            'Spring 2019-20 (Semester)',
-            'Summer 2019-20 (Semester)'
-        )
-        AND grade_c != '8th Grade'
+    --CT Status (AT) = Current CT HS Student during Spring 2019-20 AND Summer 2019-20
+    GAS_Name IN ('Spring 2019-20 (Semester)', 'Summer 2019-20 (Semester)')
+    AND grade_c != '8th Grade'
     GROUP BY
-        student_c,
-        site_short
+    student_c,
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
 --Pull meaningful summer experience data from current and previous AY (hard-entry 2019,20, 2020-21)
 gather_mse_data AS (
@@ -90,8 +78,10 @@ gather_mse_data AS (
                 ELSE 0
             END
         ) AS mse_internship_prev_AY,
+        C.Ethnic_background_c,
+        C.Gender_c
     FROM
-        `data-warehouse-289815.salesforce.student_life_activity_c` AS sl
+        `data-warehouse-289815.salesforce.student_life_activity_c` AS sl 
         LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` AS c ON c.at_id = sl.semester_c
     WHERE
         sl.record_type_id = '01246000000ZNi8AAG' #Summer Experience
@@ -101,8 +91,13 @@ gather_mse_data AS (
         AND status_c = 'Approved'
     GROUP BY
         contact_id,
-        site_short
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
+
+--pull in students that have at least 1 workshop attendance session
+--this indicates some threshold of participation in programming, even if attendance numerator < 1
 gather_attendance_data AS (
     #group attendance data by student first, aggregate at site level in prep_attendance_kpi
     SELECT
@@ -128,116 +123,148 @@ prep_attendance_kpi AS (
             WHEN sl_attendance_rate >= 0.8 THEN 1
             ELSE 0
         END AS sl_above_80_attendance,
+        Ethnic_background_c,
+        Gender_c
     FROM
         gather_contact_data as gd
         LEFT JOIN gather_attendance_data AS attendance ON gd.contact_id = attendance.student_c
 ),
+
 gather_survey_data AS (
-    SELECT
+  SELECT
+    CT.site_short,
+    -- % of students that agree or strongly agree to a statement that they have a hobby, interest, subject that they are passionate about this year'
+    -- The denominator for this metric is housed in the join_prep query.
+    SUM(CASE
+      WHEN i_have_a_hobby_or_interest_that_i_am_passionate_about_this_year IN ("Strongly Agree", 'Agree') THEN 1
+      ELSE 0
+    END) AS agree_they_have_hobby,
+    CT.Ethnic_background_c,
+    CT.Gender_c
+  FROM
+    `data-studio-260217.surveys.fy21_hs_survey` S
+    LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_template` CT ON CT.Contact_Id = S.contact_id
+    GROUP BY 
         CT.site_short,
-        -- % of students that agree or strongly agree to a statement that they have a hobby, interest, subject that they are passionate about this year'
-        -- The denominator for this metric is housed in the join_prep query.
-        SUM(
-            CASE
-                WHEN i_have_a_hobby_or_interest_that_i_am_passionate_about_this_year IN ("Strongly Agree", 'Agree') THEN 1
-                ELSE 0
-            END
-        ) AS agree_they_have_hobby
-    FROM
-        `data-studio-260217.surveys.fy21_hs_survey` S
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_template` CT ON CT.Contact_Id = S.contact_id
-    GROUP BY
-        CT.site_short
+        Ethnic_background_c,
+        Gender_c
+ 
 ),
 -- % % of students that have improved Belief-in-Self domain within the year
 -- This KPI is done over four CTEs (could probaly be made more efficient). The majority of the logic is done in the second CTE.
 gather_covi_data AS (
-    SELECT
-        contact_name_c,
-        site_short,
-        AT_Name,
-        start_date_c,
-        MIN(belief_in_self_raw_score_c) AS belief_in_self_raw_score_c
-    FROM
-        `data-warehouse-289815.salesforce_clean.test_clean` T
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.AT_Id = T.academic_semester_c
-    WHERE
-        T.record_type_id = '0121M000001cmuDQAQ'
-        AND AY_Name IN ('AY 2019-20', 'AY 2020-21')
-        AND CAT.College_track_status_c = '11A'
-    GROUP BY
-        site_short,
-        contact_name_c,
-        AT_Name,
-        start_date_c
-    ORDER BY
-        site_short,
-        contact_name_c,
-        start_date_c
+  SELECT
+    contact_name_c,
+    site_short,
+    AT_Name,
+    start_date_c,
+    MIN(
+      belief_in_self_raw_score_c
+    ) AS belief_in_self_raw_score_c,
+    CAT.Ethnic_background_c,
+    CAT.Gender_c
+  FROM
+    `data-warehouse-289815.salesforce_clean.test_clean` T
+    LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.AT_Id = T.academic_semester_c
+  WHERE
+    T.record_type_id = '0121M000001cmuDQAQ'
+    AND AY_Name IN ('AY 2019-20', 'AY 2020-21')
+    AND CAT.College_track_status_c = '11A'
+  GROUP BY
+    site_short,
+    contact_name_c,
+    AT_Name,
+    start_date_c,
+    Ethnic_background_c,
+    Gender_c
+  ORDER BY
+    site_short,
+    contact_name_c,
+    start_date_c
 ),
 calc_covi_growth AS (
-    SELECT
-        site_short,
-        contact_name_c,
-        belief_in_self_raw_score_c - lag(belief_in_self_raw_score_c) over (
-            partition by contact_name_c
-            order by
-                start_date_c
-        ) AS covi_growth
-    FROM
-        gather_covi_data
+  SELECT
+    site_short,
+    contact_name_c,
+    belief_in_self_raw_score_c - lag(belief_in_self_raw_score_c) over (
+      partition by contact_name_c
+      order by
+        start_date_c
+    ) AS covi_growth,
+    Ethnic_background_c,
+    Gender_c
+  FROM
+    gather_covi_data
 ),
 determine_covi_indicators AS (
-    SELECT
-        site_short,
-        contact_name_c,
-        CASE
-            WHEN covi_growth > 0 THEN 1
-            ELSE 0
-        END AS covi_student_grew
-    FROM
-        calc_covi_growth
-    WHERE
-        covi_growth IS NOT NULL
+  SELECT
+    site_short,
+    contact_name_c,
+    CASE
+      WHEN covi_growth > 0 THEN 1
+      ELSE 0
+    END AS covi_student_grew,
+    Ethnic_background_c,
+    Gender_c
+  FROM
+    calc_covi_growth
+  WHERE
+    covi_growth IS NOT NULL
 ),
 aggregate_covi_data AS (
-    SELECT
-        site_short,
-        SUM(covi_student_grew) AS SL_covi_belief_student_grew,
-        COUNT(contact_name_c) AS SL_covi_belief_denominator
-    FROM
-        determine_covi_indicators
-    GROUP BY
-        site_short
-),
+SELECT
+  site_short,
+  SUM(covi_student_grew) AS SL_covi_belief_student_grew,
+  COUNT(contact_name_c) AS SL_covi_belief_denominator,
+  Ethnic_background_c,
+  Gender_c
+FROM
+  determine_covi_indicators
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+  ),
+
+
 aggregate_attendance_kpi AS (
     SELECT
         site_short,
-        SUM(sl_above_80_attendance) AS sl_above_80_attendance
+        SUM(sl_above_80_attendance) AS sl_above_80_attendance,
+        Ethnic_background_c,
+        Gender_c
     FROM
         prep_attendance_kpi
     GROUP BY
-        site_short
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
 aggregate_dream_kpi AS (
     SELECT
         site_short,
-        SUM(dream_declared) as sl_dreams_declared
+        SUM(dream_declared) as sl_dreams_declared,
+        Ethnic_background_c,
+        Gender_c
     FROM
         gather_contact_data
     GROUP BY
-        site_short
+        site_short,
+        Ethnic_background_c,
+        Gender_c
 ),
 aggregate_mse_reporting_group AS (
     SELECT
-        site_short,
-        COUNT(student_c) AS sl_mse_reporting_group_prev_AY
-    FROM
-        mse_reporting_group
-    WHERE
-        current_at_count = 2
+    site_short,
+    COUNT(student_c) AS sl_mse_reporting_group_prev_AY,
+    Ethnic_background_c,
+    Gender_c
+    FROM mse_reporting_group
+    WHERE current_at_count = 2
     GROUP BY
-        site_short
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
 aggregate_mse_kpis AS (
     SELECT
@@ -245,28 +272,52 @@ aggregate_mse_kpis AS (
         SUM(mse_completed_prev_AY) AS sl_mse_completed_prev_AY,
         SUM(mse_competitive_prev_AY) AS sl_mse_competitive_prev_AY,
         SUM(mse_internship_prev_AY) AS sl_mse_internship_prev_AY,
+        Ethnic_background_c,
+        Gender_c
     FROM
         gather_mse_data AS A
     GROUP BY
-        site_short
-)
+        site_short,
+        Ethnic_background_c,
+        Gender_c
+),
+sl_final_join AS (
 SELECT
-    d.site_short,
+    CT.site_short,
+    CT.Ethnic_background_c,
+    CT.Gender_c,
     sl_dreams_declared,
     attendance_kpi.*
-EXCEPT
-    (site_short),
+        EXCEPT (site_short, Ethnic_background_c, gender_c),
     mse_kpi.*
-EXCEPT
-    (site_short),
+        EXCEPT (site_short,Ethnic_background_c, gender_c),
     sl_mse_reporting_group_prev_AY,
     GSD.agree_they_have_hobby AS sl_agree_they_have_hobby,
     ACD.SL_covi_belief_student_grew,
     ACD.SL_covi_belief_denominator
+    
 FROM
-    aggregate_dream_kpi AS d
-    LEFT JOIN aggregate_attendance_kpi AS attendance_kpi ON d.site_short = attendance_kpi.site_short
-    LEFT JOIN aggregate_mse_kpis AS mse_kpi ON d.site_short = mse_kpi.site_short
-    LEFT JOIN aggregate_mse_reporting_group AS mse_grp ON mse_grp.site_short = mse_kpi.site_short
-    LEFT JOIN gather_survey_data AS GSD ON GSD.site_short = d.site_short
-    LEFT JOIN aggregate_covi_data AS ACD ON ACD.site_short = d.site_short
+    gather_contact_data AS CT
+    LEFT JOIN aggregate_dream_kpi AS dream ON dream.site_short = CT.site_short AND dream.Ethnic_background_c = CT.Ethnic_background_c AND dream.gender_c=CT.gender_c
+    LEFT JOIN aggregate_attendance_kpi AS attendance_kpi ON CT.site_short = attendance_kpi.site_short AND CT.Ethnic_background_c = attendance_kpi.Ethnic_background_c AND CT.gender_c=attendance_kpi.gender_c
+    LEFT JOIN aggregate_mse_kpis AS mse_kpi ON CT.site_short = mse_kpi.site_short AND CT.Ethnic_background_c = mse_kpi.Ethnic_background_c AND CT.gender_c=mse_kpi.gender_c
+    LEFT JOIN aggregate_mse_reporting_group AS mse_grp ON mse_grp.site_short = CT.site_short AND mse_grp.Ethnic_background_c = CT.Ethnic_background_c AND mse_grp.gender_c=CT.gender_c
+    LEFT JOIN gather_survey_data AS GSD ON GSD.site_short = CT.site_short AND CT.Ethnic_background_c = GSD.Ethnic_background_c AND CT.gender_c=GSD.gender_c
+    LEFT JOIN aggregate_covi_data AS ACD ON ACD.site_short = CT.site_short AND CT.Ethnic_background_c = ACD.Ethnic_background_c AND CT.gender_c=ACD.gender_c
+
+group by 
+    site_short,
+    Ethnic_background_c,
+    Gender_c,
+    sl_dreams_declared,
+    sl_above_80_attendance,
+    sl_mse_completed_prev_AY,
+    sl_mse_competitive_prev_AY,
+    sl_mse_internship_prev_AY ,
+    sl_mse_reporting_group_prev_AY ,
+    agree_they_have_hobby,
+    SL_covi_belief_student_grew ,
+    SL_covi_belief_denominator
+)
+SELECT *
+FROM sl_final_join 

--- a/wellness.sql
+++ b/wellness.sql
@@ -1,163 +1,183 @@
-/*
- CREATE OR REPLACE TABLE `data-studio-260217.kpi_dashboard.wellness` 
- OPTIONS
- (
- description= "Aggregating Wellness metrics for the Data Studio KPI dashboard"
- )
- AS
- */
-WITH --Gather contact and academic term data to join with COVI data to set reporting groups
-gather_at_data AS (
-    SELECT
-        full_name_c,
-        at_id,
-        contact_id,
-        AY_Name,
-        site_short
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template`
-    WHERE
-        College_Track_Status_Name = 'Current CT HS Student'
-        AND (
-            grade_c IN ('9th Grade', '10th Grade', '11th Grade')
-            OR (
-                grade_c = "12th Grade"
-                OR (
-                    grade_c = 'Year 1'
-                    AND indicator_years_since_hs_graduation_c = 0
-                )
-            )
-        )
+WITH
+
+--Gather contact and academic term data to join with COVI data to set reporting groups
+gather_at_data AS
+(
+SELECT
+    full_name_c,
+    at_id,
+    contact_id,
+    AY_Name,
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+
+FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+WHERE College_Track_Status_Name = 'Current CT HS Student'
+    AND
+        (grade_c IN ('9th Grade','10th Grade','11th Grade')
+        OR
+        (grade_c = "12th Grade" OR (grade_c='Year 1' AND indicator_years_since_hs_graduation_c = 0)))
 ),
---Pull Covi assessments completed within appropriate AYs (2019-20, 2020-21)
+
+--Pull Covi assessments completed within appropriate AYs (2020-21)
 gather_covi_data AS (
-    SELECT
-        contact_name_c AS contact_id_covi,
-        contact_id,
-        --from contact_at
-        id AS test_record_id,
-        site_short,
-        AY_Name,
-        co_vitality_scorecard_color_c,
-        belief_in_self_raw_score_c,
-        engaged_living_raw_score_c,
-        belief_in_others_raw_score_c,
-        emotional_competence_raw_score_c,
-    FROM
-        `data-warehouse-289815.salesforce_clean.test_clean` AS COVI
-        LEFT JOIN gather_at_data AS GAD ON GAD.at_id = COVI.academic_semester_c
-    WHERE
-        COVI.record_type_id = '0121M000001cmuDQAQ' --Covitality test record type
-        AND status_c = 'Completed'
-        AND AY_Name = 'AY 2020-21'
+SELECT
+    contact_name_c AS contact_id_covi,
+    contact_id, --from contact_at
+    id AS test_record_id,
+    site_short,
+    AY_Name,
+    co_vitality_scorecard_color_c,
+    belief_in_self_raw_score_c,
+    engaged_living_raw_score_c,
+    belief_in_others_raw_score_c,
+    emotional_competence_raw_score_c,
+    GAD.Ethnic_background_c,
+    GAD.Gender_c
+
+FROM `data-warehouse-289815.salesforce_clean.test_clean` AS COVI
+LEFT JOIN gather_at_data AS GAD
+    ON GAD.at_id = COVI.academic_semester_c
+
+WHERE COVI.record_type_id ='0121M000001cmuDQAQ' --Covitality test record type
+    AND status_c = 'Completed'
+    AND AY_Name = 'AY 2020-21'
 ),
+
 --Setting groundwork for KPI indicator: % of students who have taken the the CoVi assessment each academic year (2020-21AY)
 --Gathered in 2 CTEs
 completing_covi_data AS (
-    SELECT
-        site_short,
-        contact_id,
-        CASE
-            WHEN test_record_id IS NOT NULL THEN 1
-            ELSE 0
-        END AS covi_assessment_completed_ay
-    FROM
-        gather_covi_data
-    WHERE
-        AY_Name = 'AY 2020-21'
-    GROUP BY
-        contact_id,
-        site_short,
-        test_record_id
+SELECT
+    site_short,
+    contact_id,
+    CASE
+        WHEN test_record_id IS NOT NULL
+        THEN 1
+        ELSE 0
+        END AS covi_assessment_completed_ay,
+    Ethnic_background_c,
+    Gender_c
+FROM gather_covi_data
+WHERE AY_Name = 'AY 2020-21'
+GROUP BY
+    contact_id,
+    site_short,
+    test_record_id,
+    Ethnic_background_c,
+    Gender_c
 ),
+
 --Isolate students that completed a Covitality assessment in 2020-21AY
 students_that_completed_covi AS (
-    SELECT
-        COUNT(DISTINCT contact_id) AS wellness_covi_assessment_completed_ay,
-        site_short
-    FROM
-        completing_covi_data
-    WHERE
-        covi_assessment_completed_ay = 1
-    GROUP BY
-        site_short
+SELECT
+    COUNT(DISTINCT contact_id) AS wellness_covi_assessment_completed_ay,
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+
+FROM completing_covi_data
+WHERE covi_assessment_completed_ay = 1
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
+
 -- KPI: % of students served by Wellness who "strongly agree" wellness services assisted them in managing their stress, helping them engage in self-care practices and/or enhancing their mental health
 -- The denominator for this metric will be students who answered "yes" to receiving wellness services
 gather_wellness_survey_data AS (
-    SELECT
-        CT.site_short,
-        S.contact_id AS students_receiving_wellness_services,
-        CASE
-            WHEN (
-                working_with_college_track_wellness_services_has_assisted_you_in_managing_your_s IN ("Strongly Agree", "Totalmente de acuerdo")
-                OR working_with_college_tracks_wellness_programming_has_helped_you_engage_in_self_c IN ("Strongly Agree", "Totalmente de acuerdo")
-                OR working_with_college_tracks_wellness_services_has_enhanced_your_mental_health IN ("Strongly Agree", "Totalmente de acuerdo")
-            ) THEN 1
-            ELSE 0
-        END AS strongly_agree_wellness_services_assisted_them
-    FROM
-        `data-studio-260217.surveys.fy21_hs_survey` S
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_template` CT ON CT.Contact_Id = S.contact_id
-    WHERE
-        did_you_engage_with_wellness_services_at_your_site = "Yes"
+SELECT
+    CT.site_short,
+    S.contact_id AS students_receiving_wellness_services,
+
+    CASE
+        WHEN (
+            working_with_college_track_wellness_services_has_assisted_you_in_managing_your_s IN ("Strongly Agree", "Totalmente de acuerdo")
+            OR working_with_college_tracks_wellness_programming_has_helped_you_engage_in_self_c IN ("Strongly Agree", "Totalmente de acuerdo")
+            OR working_with_college_tracks_wellness_services_has_enhanced_your_mental_health IN ("Strongly Agree", "Totalmente de acuerdo")
+            )
+        THEN 1
+        ELSE 0
+        END AS strongly_agree_wellness_services_assisted_them,
+        CT.Ethnic_background_c,
+        CT.Gender_c
+
+FROM `data-studio-260217.surveys.fy21_hs_survey` S
+    LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_template` CT ON CT.Contact_Id = S.contact_id
+WHERE did_you_engage_with_wellness_services_at_your_site = "Yes"
 ),
+
 aggregate_wellness_survey_data AS (
-    SELECT
-        COUNT (DISTINCT students_receiving_wellness_services) AS wellness_survey_wellness_services_assisted_denom,
-        SUM(strongly_agree_wellness_services_assisted_them) AS wellness_survey_wellness_services_assisted_num,
-        site_short
-    FROM
-        gather_wellness_survey_data
-    GROUP BY
-        site_short
+SELECT
+    COUNT (DISTINCT students_receiving_wellness_services) AS wellness_survey_wellness_services_assisted_denom,
+    SUM(strongly_agree_wellness_services_assisted_them) AS wellness_survey_wellness_services_assisted_num,
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+FROM gather_wellness_survey_data
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
+
+
 --Average # of sessions for reb/blue Covi students or 1:1 (case notes)
 --% of students/# of sessions/amt of time that students with red and blue CoVi scores have spent receiving support/counseling/coaching for their social emotional wellbeing health (either through a workshop, small group or 1:1s)
 --Broken down into various CTEs to gather students with red/blue covi, wellness sessions attended, and case notes logged
+
 --Pulling students with red/blue covi from academic term (2020-21AY)
 gather_red_blue_covi_at AS (
-    SELECT
+SELECT
         contact_id,
         site_short,
         co_vitality_scorecard_color_c,
-        MAX(
-            CASE
-                WHEN co_vitality_scorecard_color_c IN ('Blue', 'Red') THEN 1
-                ELSE NULL
-            END
-        ) AS wellness_blue_red_denom
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template`
-    WHERE
-        grade_c != '8th Grade'
-        AND college_track_status_c = '11A'
-        AND AY_NAME = "AY 2020-21"
-        AND Term_c = "Fall"
-    GROUP BY
-        contact_Id,
-        site_short,
-        co_vitality_scorecard_color_c
+   MAX(CASE
+            WHEN co_vitality_scorecard_color_c IN ('Blue','Red')
+            THEN 1
+            ELSE NULL
+        END) AS wellness_blue_red_denom,
+
+        Ethnic_background_c,
+        Gender_c
+FROM `data-warehouse-289815.salesforce_clean.contact_at_template`
+WHERE grade_c != '8th Grade'
+    AND college_track_status_c = '11A'
+    AND AY_NAME = "AY 2020-21"
+    AND Term_c = "Fall"
+GROUP BY
+    contact_Id,
+    site_short,
+    co_vitality_scorecard_color_c,
+    Ethnic_background_c,
+    Gender_c
 ),
+
 --Sum students that have a red or blue covitality color at some point during 2020-21AY
 sum_of_blue_red_covi AS (
-    SELECT
+SELECT
         site_short,
-        SUM(wellness_blue_red_denom) AS sum_of_blue_red_covi_for_avg #students with blue/red Covitality scorecard colors for denominator
-    FROM
-        gather_red_blue_covi_at
-    GROUP BY
-        site_short
+        SUM(wellness_blue_red_denom) AS sum_of_blue_red_covi_for_avg, #students with blue/red Covitality scorecard colors for denominator
+        Ethnic_background_c,
+        Gender_c
+FROM gather_red_blue_covi_at
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
---gather Wellness sessions attended during 2020-21
+
+ --gather Wellness sessions attended during 2020-21
 gather_wellness_attendance_data AS (
-    SELECT
-        SUM(attendance_numerator_c) AS sum_attended_wellness_sessions,
-        site_short
-    FROM
-        `data-warehouse-289815.salesforce_clean.class_template` CT
-        LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.AT_Id = CT.Academic_Semester_c
-    WHERE
+SELECT
+    SUM(attendance_numerator_c) AS sum_attended_wellness_sessions,
+    site_short,
+    CAT.Ethnic_background_c,
+    CAT.Gender_c
+    FROM `data-warehouse-289815.salesforce_clean.class_template` CT
+    LEFT JOIN `data-warehouse-289815.salesforce_clean.contact_at_template` CAT ON CAT.AT_Id = CT.Academic_Semester_c
+        WHERE
         Attendance_Numerator_c > 0
         AND department_c = 'Wellness'
         AND dosage_types_c NOT LIKE '%NSO%'
@@ -165,102 +185,107 @@ gather_wellness_attendance_data AS (
         AND grade_c != '8th Grade'
         AND Outcome_c != 'Cancelled'
         AND college_track_status_c = '11A'
-        AND contact_id IN (
-            SELECT
-                contact_id
-            FROM
-                `data-warehouse-289815.salesforce_clean.contact_at_template`
-            where
-                co_vitality_scorecard_color_c IN ('Blue', 'Red')
-                AND AY_name = "AY 2020-21"
-                AND Term_c = "Fall"
-        )
+        AND contact_id IN (SELECT contact_id FROM `data-warehouse-289815.salesforce_clean.contact_at_template` where co_vitality_scorecard_color_c IN  ('Blue','Red') AND AY_name = "AY 2020-21" AND Term_c = "Fall")
     GROUP BY
-        site_short
+            site_short,
+            Ethnic_background_c,
+            Gender_c
 ),
+
 --Prepare case note data for aggregation: red/blue covi as receiving 1:1 support by site. Will be used to add together with Wellness sessions attended
 --1 casenote = 1 session
 gather_case_note_data AS (
-    SELECT
-        COUNT (DISTINCT CSE.id) AS case_note_count,
-        #case note id
-        site_short
-    FROM
-        `data-warehouse-289815.salesforce_clean.contact_at_template` CAT
-        LEFT JOIN `data-warehouse-289815.salesforce.progress_note_c` CSE ON CAT.AT_Id = CSE.Academic_Semester_c
-    WHERE
-        Type_Counseling_c = TRUE
-        AND AY_name = 'AY 2020-21'
-        AND college_track_status_c = '11A'
-        AND contact_id IN (
-            SELECT
-                contact_id
-            FROM
-                `data-warehouse-289815.salesforce_clean.contact_at_template`
-            where
-                co_vitality_scorecard_color_c IN ('Blue', 'Red')
-                AND AY_name = "AY 2020-21"
-                AND Term_c = "Fall"
-        )
-    GROUP BY
-        site_short
+SELECT
+    COUNT (DISTINCT CSE.id) AS case_note_count, #case note id
+    site_short,
+    CAT.Ethnic_background_c,
+    CAT.Gender_c
+
+FROM `data-warehouse-289815.salesforce_clean.contact_at_template` CAT
+LEFT JOIN `data-warehouse-289815.salesforce.progress_note_c` CSE ON CAT.AT_Id = CSE.Academic_Semester_c
+WHERE Type_Counseling_c = TRUE
+    AND AY_name = 'AY 2020-21'
+    AND college_track_status_c = '11A'
+    AND contact_id IN (SELECT contact_id FROM `data-warehouse-289815.salesforce_clean.contact_at_template` where co_vitality_scorecard_color_c IN  ('Blue','Red') AND AY_name = "AY 2020-21" AND Term_c = "Fall")
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
 ),
+
 --Add 1:1 case notes and sessions attended by student to average out later
 combine_sessions_and_case_notes AS (
-    SELECT
-        ATTNDCE.site_short,
-        SUM(sum_attended_wellness_sessions + case_note_count) AS sum_wellness_support_received
-    FROM
-        gather_wellness_attendance_data AS ATTNDCE
-        LEFT JOIN gather_case_note_data AS CSE ON ATTNDCE.site_short = CSE.site_short
-    GROUP BY
-        site_short
-),
-calculate_avg_wellness_services_per_blue_red_covi AS (
-    SELECT
-        a.site_short,
-        CASE
-            WHEN wellness_blue_red_denom IS NOT NULL THEN (
-                sum_wellness_support_received / sum_of_blue_red_covi_for_avg
-            )
-            ELSE NULL
-        END AS wellness_avg_support,
-        # of sessions or 1:1 / Students with reb,blue Covi scorecard color
-    FROM
-        combine_sessions_and_case_notes AS a
-        LEFT JOIN sum_of_blue_red_covi AS b ON a.site_short = b.site_short
-        LEFT JOIN gather_red_blue_covi_at AS C ON a.site_short = c.site_short
-    WHERE
-        wellness_blue_red_denom IS NOT NULL
-),
-aggregate_kpis_data AS(
-    SELECT
-        a.site_short,
-        wellness_covi_assessment_completed_ay,
-        wellness_avg_support,
-        sum_attended_wellness_sessions,
-        case_note_count,
-        sum_of_blue_red_covi_for_avg,
-        wellness_survey_wellness_services_assisted_denom,
-        wellness_survey_wellness_services_assisted_num
-    FROM
-        students_that_completed_covi AS a
-        LEFT JOIN aggregate_wellness_survey_data AS b ON b.site_short = a.site_short
-        LEFT JOIN calculate_avg_wellness_services_per_blue_red_covi AS c ON c.site_short = a.site_short
-        LEFT JOIN gather_wellness_attendance_data AS d ON a.site_short = d.site_short --for total sessions
-        LEFT JOIN gather_case_note_data AS e ON a.site_short = e.site_short --for total case notes
-        LEFT JOIN sum_of_blue_red_covi AS f ON a.site_short = f.site_short --for stotal number of red/blue covi students
-    GROUP BY
-        site_short,
-        wellness_covi_assessment_completed_ay,
-        wellness_avg_support,
-        sum_attended_wellness_sessions,
-        case_note_count,
-        sum_of_blue_red_covi_for_avg,
-        wellness_survey_wellness_services_assisted_denom,
-        wellness_survey_wellness_services_assisted_num
-)
 SELECT
-    *
-FROM
-    aggregate_kpis_data
+    ATTNDCE.site_short,
+    SUM(sum_attended_wellness_sessions + case_note_count) AS sum_wellness_support_received,
+    ATTNDCE.Ethnic_background_c,
+    ATTNDCE.Gender_c
+
+FROM gather_wellness_attendance_data AS ATTNDCE
+LEFT JOIN gather_case_note_data AS CSE ON ATTNDCE.site_short = CSE.site_short
+GROUP BY
+    site_short,
+    Ethnic_background_c,
+    Gender_c
+),
+
+calculate_avg_wellness_services_per_blue_red_covi AS (
+SELECT
+    a.site_short,
+    CASE
+        WHEN wellness_blue_red_denom IS NOT NULL
+        THEN (sum_wellness_support_received/sum_of_blue_red_covi_for_avg)
+        ELSE NULL
+        END AS wellness_avg_support, # of sessions or 1:1 / Students with reb,blue Covi scorecard color
+    a.Ethnic_background_c,
+    a.Gender_c
+
+FROM combine_sessions_and_case_notes AS a
+LEFT JOIN sum_of_blue_red_covi AS b ON a.site_short=b.site_short AND a.ethnic_background_c=b.ethnic_background_c AND a.Gender_c=b.Gender_c
+LEFT JOIN gather_red_blue_covi_at AS C ON a.site_short=c.site_short AND a.ethnic_background_c=c.ethnic_background_c AND c.Gender_c=b.Gender_c
+WHERE wellness_blue_red_denom IS NOT NULL
+
+),
+prep_avg_wellness_services AS (
+SELECT
+    site_short,
+    wellness_avg_support, # of sessions or 1:1 / Students with reb,blue Covi scorecard color
+    Ethnic_background_c,
+    Gender_c
+
+FROM calculate_avg_wellness_services_per_blue_red_covi AS a
+GROUP BY
+    a.site_short,
+    wellness_avg_support,
+    Ethnic_background_c,
+    Gender_c
+),
+
+aggregate_kpis_data AS(
+SELECT
+    a.site_short,
+    MAX(wellness_covi_assessment_completed_ay) AS wellness_covi_assessment_completed_ay,
+    wellness_avg_support,
+    MAX(sum_attended_wellness_sessions) AS sum_attended_wellness_sessions,
+    MAX(case_note_count) AS case_note_count,
+    MAX(sum_of_blue_red_covi_for_avg) AS sum_of_blue_red_covi_for_avg,
+    MAX(wellness_survey_wellness_services_assisted_denom) AS wellness_survey_wellness_services_assisted_denom,
+    MAX(wellness_survey_wellness_services_assisted_num) AS wellness_survey_wellness_services_assisted_num,
+    a.Ethnic_background_c,
+    a.Gender_c
+
+FROM students_that_completed_covi AS a
+LEFT JOIN aggregate_wellness_survey_data AS b ON b.site_short = a.site_short AND a.ethnic_background_c = b.ethnic_background_c AND a.Gender_c=b.Gender_c
+LEFT JOIN prep_avg_wellness_services AS c ON c.site_short = a.site_short AND a.ethnic_background_c = c.ethnic_background_c AND a.Gender_c=c.Gender_c
+LEFT JOIN gather_wellness_attendance_data AS d ON a.site_short = d.site_short AND a.ethnic_background_c = d.ethnic_background_c AND a.Gender_c=d.Gender_c--for total sessions
+LEFT JOIN gather_case_note_data AS e ON a.site_short=e.site_short AND a.ethnic_background_c = e.ethnic_background_c AND a.Gender_c=e.Gender_c --for total case notes
+LEFT JOIN sum_of_blue_red_covi AS f ON a.site_short=f.site_short AND a.ethnic_background_c = f.ethnic_background_c AND a.Gender_c=f.Gender_c --for stotal number of red/blue covi students
+GROUP BY
+    site_short,
+    wellness_avg_support,
+    Ethnic_background_c,
+    Gender_c
+)
+
+SELECT *
+FROM aggregate_kpis_data


### PR DESCRIPTION
@isabelreyna and @jvolan123 here is the start of a pull request that modifies the code to include ethnic and gender breakdowns. 

For most of the queries it is a really simple addition, you just add the ethinc and gender columns in the SELECT statement and the GROUP BY statement. 

For some queries, especially ones that use lots of CTEs to pre-aggregate data it is a bit thicker because you have to group by the columns multiple times and then join on site_short, ethnic_background_c, and gender_c. 

When possible, I tried to restructure the query to only do one group by at the very end. I had to restructure the RED query a lot to get this to work if you want to use that as an example. For other queries, like the SD one though that was too complicated so I left the structure as is, but just added the extra columns/ joins/ group bys. 



